### PR TITLE
chore: Remove Sentry test endpoint

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,22 +1,11 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.http import HttpResponse
 from django.urls import include, path
 
 from core.views import Health, SecureEcho  # add
 from sso.admin_oauth_views import admin_oauth_callback, admin_oauth_login
 from sso.views import google_auth_callback
-
-
-def sentry_test_error(request):
-    """
-    Temporary test endpoint - DELETE after Sentry verification.
-    Triggers a ZeroDivisionError to test Sentry integration.
-    """
-    1 / 0  # noqa: B018
-    return HttpResponse("This line will never execute")
-
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -36,8 +25,6 @@ urlpatterns = [
     path("auth/", include("sso.urls")),  # Also include under /auth/ for admin OAuth
     path("health/", Health.as_view()),  # add
     path("secure/", SecureEcho.as_view()),  # add
-    # TEMPORARY: Remove after Sentry verification
-    path("sentry-test/", sentry_test_error, name="sentry_test"),
     path("", include("dashboard.urls")),
 ]
 


### PR DESCRIPTION
## Summary
Remove temporary Sentry test endpoint from production code.

## Changes
- ✅ Removed `/sentry-test/` URL pattern
- ✅ Removed `sentry_test_error()` function
- ✅ Removed unused `HttpResponse` import

## Context
The test endpoint was used for initial Sentry verification. Now that Sentry is deployed and active in production, the test endpoint is no longer needed. Real errors are being captured automatically.

## Testing
- No testing required - this is purely a removal of test code
- Sentry continues to work normally after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)