### PR TITLE
feat: add provision_tenant management command for SSO tenant onboarding

### DIFF
--- a/docs/tenant-onboarding.md
+++ b/docs/tenant-onboarding.md
@@ -37,7 +37,12 @@ Edit `tenants/msp.yaml`:
   from the JWT (`application_roles.<slug>.role`); use `Admin` / `Operator` / `Client`
   to match CBRTConnect's expectations unless you know otherwise.
 - `users`: one entry per (user, role) binding. A user with multiple roles gets
-  multiple entries. Each user has an `auth_type`:
+  multiple entries. **Emails are normalized to lowercase** before any DB
+  interaction — `Bjackson@domain.com` and `bjackson@domain.com` are treated as
+  the same user, and the row is stored as `bjackson@domain.com`. If the DB
+  already contains two rows that differ only by case (legacy data), the
+  command refuses to run and tells you to deduplicate in `/cbrt-ops/` first.
+  Each user has an `auth_type`:
   - `email` (default) — user will have an email + temp password. Use for tenant
     clients who are **not** on Google Workspace (e.g. `@marianshipping.com`).
     The command generates a 24-char cryptographic password per user and prints

--- a/docs/tenant-onboarding.md
+++ b/docs/tenant-onboarding.md
@@ -1,0 +1,196 @@
+# Tenant Onboarding Runbook
+
+Operational guide for provisioning a new tenant on `sso.barge2rail.com` using
+the `provision_tenant` management command.
+
+This replaces the ~20-click flow through `/cbrt-ops/` (Django admin) with a
+single YAML-driven command. Review the YAML, dry-run, run for real, capture the
+`client_secret`. Done.
+
+## Prerequisites
+
+1. **You must have an SSO user** at `sso.barge2rail.com`. The command records
+   you as the `--actor` on the Application and every UserAppRole. If no user
+   with your email exists, the command fails with a message telling you to
+   create one via `/cbrt-ops/` first.
+2. **Repo checkout + activated venv**: `cd ~/Projects/barge2rail-auth && source venv/bin/activate`.
+3. **Database access** for the environment you're provisioning against
+   (usually dev first, then prod via `git push origin main` + remote shell).
+
+## Step 1 — Fill in the YAML
+
+Copy the template:
+
+```bash
+cp tenants/_template.yaml tenants/msp.yaml   # replace msp with the tenant_code
+```
+
+Edit `tenants/msp.yaml`:
+
+- `tenant_code`: short uppercase code (1-10 chars). Must be unique across tenants.
+- `display_name`: full tenant name (used for the `Tenant` reference row).
+- `application.name`: unique across all SSO Applications — include the tenant code
+  (e.g., `"CBRTConnect - MSP"`) to avoid collision.
+- `application.redirect_uris`: OAuth redirect URIs as a list. Trailing slashes must
+  match exactly what the client app sends (Oct 2025 lesson learned).
+- `roles`: the roles this tenant will use. `legacy_role` is what client apps read
+  from the JWT (`application_roles.<slug>.role`); use `Admin` / `Operator` / `Client`
+  to match CBRTConnect's expectations unless you know otherwise.
+- `users`: one entry per (user, role) binding. A user with multiple roles gets
+  multiple entries. Each user has an `auth_type`:
+  - `email` (default) — user will have an email + temp password. Use for tenant
+    clients who are **not** on Google Workspace (e.g. `@marianshipping.com`).
+    The command generates a 24-char cryptographic password per user and prints
+    it once in the banner at end of run. Distribute privately; the user then
+    changes it at `https://sso.barge2rail.com/change-password/` on first login.
+  - `google` — user will sign in via Google OAuth. No password is stored. Use
+    for `@barge2rail.com` staff.
+  - `anonymous` — not supported by `provision_tenant`. Create via `/cbrt-ops/`.
+
+The Application `slug` is auto-derived as `cbrtconnect-<tenant_code.lower()>`.
+
+**Do not commit the filled-in YAML.** `tenants/.gitignore` blocks everything except
+`_template.yaml`. Keep the filled YAML locally or in 1Password — it contains user PII.
+
+## Step 2 — Dry-run
+
+```bash
+python manage.py provision_tenant --config tenants/msp.yaml --dry-run
+```
+
+Expected output: a plan listing `CREATE` or `SKIP (exists)` for the Tenant,
+Application, each Role, each User, and each UserAppRole binding. Nothing is
+written to the database. If validation fails (missing field, bad email, unknown
+role reference, etc.), you'll get a specific error with a field path — fix the
+YAML and re-run the dry-run.
+
+## Step 3 — Real run
+
+```bash
+python manage.py provision_tenant \
+  --config tenants/msp.yaml \
+  --actor you@barge2rail.com
+```
+
+If successful, the command:
+
+1. Writes all records in a single transaction.
+2. Appends one JSON line to `logs/tenant_provisioning.jsonl` (no secrets in it).
+3. Prints a one-time secret banner to stdout:
+
+   ```
+   ================================================================
+   COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN
+   ================================================================
+   client_id:     app_xxxxxxxxxxxxxxxx
+   client_secret: <64 chars>
+   ================================================================
+   ```
+
+**Copy `client_secret` to 1Password immediately.** It is NOT stored anywhere
+else on disk and cannot be recovered later — only rotated (via `/cbrt-ops/`).
+
+If the YAML included any `auth_type: email` users, a second banner follows
+listing each new user's email and their one-time temp password:
+
+```
+================================================================
+COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN
+Email/password users (temp passwords - distribute privately):
+================================================================
+  briana@marianshipping.example.com   <24-char password>
+================================================================
+```
+
+These temp passwords are stored hashed (Django `set_password()`), never written
+to `logs/tenant_provisioning.jsonl`, and cannot be recovered — only reset via
+the password-reset flow. **Distribute via 1Password share or another
+end-to-end-encrypted channel; never Slack/email plaintext.**
+
+## What to tell email/password users after provisioning
+
+Send each email user:
+
+1. Their login URL: `https://sso.barge2rail.com/`
+2. Their email (the login identifier).
+3. Their one-time temp password (via 1Password share, Signal, or in person).
+4. Instructions: "On first login you'll land on the dashboard. Go to
+   `https://sso.barge2rail.com/change-password/` and set your own password.
+   If you forget it later, use `https://sso.barge2rail.com/forgot-password/`
+   to request a reset email."
+
+Temp passwords pass Django's minimum-length validator (4 chars) — the user
+is free to choose any password meeting that same minimum when they change it.
+
+## Step 4 — Store and clean up
+
+- **`client_secret`** → 1Password item named `SSO: <tenant_code> client secret`.
+  Also store `client_id` alongside it (not secret, but needed to configure the
+  client app).
+- **Filled YAML** → 1Password attachment on the same item, or a private local
+  directory outside the repo. Do not email, Slack, or Drive it.
+- Share `client_id` + `client_secret` with the client app team via 1Password
+  share link or password manager, never plaintext channels.
+
+## Idempotency
+
+Re-running the same YAML is safe. Existing rows are reported as
+`SKIP (exists)`. The command exits 0 and still appends an audit line
+(`application_skipped: true`, `bindings_created: 0` for a full no-op).
+
+If the Application already exists, the secret banner is **not** reprinted —
+the command can't retrieve the plaintext. If you lost it, rotate via
+`/cbrt-ops/` and update the client app.
+
+Same for email/password users: on re-run, existing users are SKIP'd and no
+temp password is printed. If a user lost theirs, they use the
+`/forgot-password/` flow (or an admin resets via `/cbrt-ops/`).
+
+### auth_type mismatch
+
+If a user email already exists in the DB with a different `auth_type` than
+the YAML specifies, the command prints an `auth_type mismatch` warning on
+the SKIP line (e.g. `yaml=email, db=google`) and **does not modify** the
+existing user. This is informational — investigate whether the YAML or the
+existing row is wrong; fix via `/cbrt-ops/` if the DB record should change.
+
+## If something goes wrong
+
+- **Validation error**: YAML field path is in the error message. Fix and re-run
+  dry-run.
+- **`Actor '<email>' has no SSO user`**: Create yourself via `/cbrt-ops/` first,
+  then re-run.
+- **Mid-transaction failure**: nothing is written (transactional). Fix the
+  underlying cause (usually a DB constraint or a migration mismatch) and re-run.
+- **Wrong data got created**: the command prints `application_id` + user emails
+  in the audit line. Open `/cbrt-ops/`, delete the Application (cascades
+  UserAppRoles and Roles), delete the Users and Tenant manually.
+
+## Audit log
+
+`logs/tenant_provisioning.jsonl` — one line per run (dry-runs are NOT appended).
+Each line: `ts`, `actor`, `tenant_code`, `application_id`, `application_name`,
+`application_skipped`, `roles_created`, `users_created`, `bindings_created`,
+`dry_run`. Explicitly contains no `client_id`, no `client_secret`, and no
+email/password user temp passwords.
+
+Review with:
+
+```bash
+cat logs/tenant_provisioning.jsonl | jq .
+```
+
+## Verification checklist (post-run)
+
+1. `/cbrt-ops/` → Applications → new Application exists with correct name, slug, redirect URIs.
+2. `/cbrt-ops/` → Users → each YAML user exists with correct name and the
+   `auth_type` specified in the YAML (`email` or `google`). Email users have
+   a usable password; Google users do not.
+3. `/cbrt-ops/` → UserAppRoles → each (user, role, tenant_code) binding is present and `is_active`.
+4. `/cbrt-ops/` → Tenants → tenant row exists with correct code and display name.
+5. For an email/password user: sign in at `https://sso.barge2rail.com/` with
+   the temp password; confirm the change-password page is reachable at
+   `/change-password/`.
+6. For a Google user: log in to the client app (CBRTConnect) via Google; the
+   JWT should include `application_roles.<slug>.tenant_code == "<TENANT_CODE>"`
+   and `application_roles.<slug>.role == "<legacy_role>"`.

--- a/sso/management/commands/_tenant_schema.py
+++ b/sso/management/commands/_tenant_schema.py
@@ -1,0 +1,122 @@
+"""YAML schema for `provision_tenant`. Not a public API — leading underscore.
+
+Validation is strict: unknown fields are rejected, role references must resolve,
+and every string that looks like a URL or email is parsed, not just regex-matched.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    field_validator,
+    model_validator,
+)
+
+TENANT_CODE_RE = re.compile(r"^[A-Z0-9]{1,10}$")
+# Pragmatic email regex: good enough to catch typos in hand-written YAML.
+# Deep RFC 5322 conformance would require the email-validator package (not a
+# current dep) and is overkill for a human-reviewed config file.
+EMAIL_RE = re.compile(r"^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$")
+
+
+class RoleSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str = Field(min_length=1, max_length=50)
+    name: str = Field(min_length=1, max_length=100)
+    legacy_role: str = Field(min_length=1, max_length=50)
+
+
+class UserSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: str = Field(min_length=3, max_length=254)
+    first_name: str = Field(min_length=1, max_length=150)
+    last_name: str = Field(min_length=1, max_length=150)
+    role: str = Field(min_length=1, max_length=50)
+    # Defaults to 'email' because client users (the common case) are not Google
+    # Workspace accounts. Staff using Google SSO must set this explicitly.
+    auth_type: str = Field(default="email")
+
+    @field_validator("email")
+    @classmethod
+    def _check_email(cls, v: str) -> str:
+        if not EMAIL_RE.match(v):
+            raise ValueError(f"'{v}' does not look like a valid email address")
+        return v
+
+    @field_validator("auth_type")
+    @classmethod
+    def _check_auth_type(cls, v: str) -> str:
+        if v == "anonymous":
+            raise ValueError(
+                "auth_type 'anonymous' is not supported by provision_tenant "
+                "(requires a PIN field and a different flow; create anonymous "
+                "users via /cbrt-ops/ admin instead)"
+            )
+        if v not in ("email", "google"):
+            raise ValueError(f"auth_type must be 'email' or 'google', got '{v}'")
+        return v
+
+
+class ApplicationSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=255)
+    redirect_uris: List[HttpUrl] = Field(min_length=1)
+
+
+class TenantConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tenant_code: str
+    display_name: str = Field(min_length=1, max_length=100)
+    application: ApplicationSpec
+    roles: List[RoleSpec] = Field(min_length=1)
+    users: List[UserSpec] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _check_tenant_code(self) -> "TenantConfig":
+        if not TENANT_CODE_RE.match(self.tenant_code):
+            raise ValueError(
+                f"tenant_code '{self.tenant_code}' must match {TENANT_CODE_RE.pattern} "
+                "(uppercase letters/digits, 1-10 chars)"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _check_role_codes_unique(self) -> "TenantConfig":
+        seen: set[str] = set()
+        for i, role in enumerate(self.roles):
+            if role.code in seen:
+                raise ValueError(f"roles.{i}.code: duplicate role code '{role.code}'")
+            seen.add(role.code)
+        return self
+
+    @model_validator(mode="after")
+    def _check_user_role_refs(self) -> "TenantConfig":
+        valid_codes = {r.code for r in self.roles}
+        for i, user in enumerate(self.users):
+            if user.role not in valid_codes:
+                raise ValueError(
+                    f"users.{i}.role: unknown role '{user.role}' "
+                    f"(not in roles[].code: {sorted(valid_codes)})"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _check_user_emails_unique(self) -> "TenantConfig":
+        seen: set[str] = set()
+        for i, user in enumerate(self.users):
+            # EmailStr comparison is case-sensitive; normalize for the dup check only.
+            normalized = str(user.email).lower()
+            if normalized in seen:
+                raise ValueError(f"users.{i}.email: duplicate email '{user.email}'")
+            seen.add(normalized)
+        return self

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -1,0 +1,413 @@
+"""Provision a new tenant: Application + Roles + Users + UserAppRole bindings.
+
+Usage:
+    python manage.py provision_tenant --config tenants/msp.yaml --dry-run
+    python manage.py provision_tenant --config tenants/msp.yaml --actor you@barge2rail.com
+
+Idempotent: re-running the same YAML reports SKIP for existing rows and exits 0.
+Transactional: any mid-run failure rolls back all writes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from pydantic import ValidationError
+
+from sso.models import Application, Role, Tenant, User, UserAppRole
+
+from ._tenant_schema import TenantConfig
+
+
+class Command(BaseCommand):
+    help = "Provision a tenant (Application, Roles, Users, UserAppRoles) from a YAML config."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--config", required=True, type=str, help="Path to tenant YAML file"
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Validate and print plan; no DB writes",
+        )
+        parser.add_argument(
+            "--actor",
+            type=str,
+            default=None,
+            help="Email of SSO user performing the provision (required for real run)",
+        )
+
+    def handle(self, *args, **options):
+        config_path = Path(options["config"])
+        dry_run: bool = options["dry_run"]
+        actor_email: str | None = options["actor"]
+
+        cfg = self._load_and_validate(config_path)
+
+        if dry_run and actor_email:
+            raise CommandError(
+                "--actor is not accepted with --dry-run (dry-run performs no writes)"
+            )
+        if not dry_run and not actor_email:
+            raise CommandError("--actor <email> is required for real runs")
+
+        actor = None if dry_run else self._resolve_actor(actor_email)
+
+        plan = self._build_plan(cfg)
+        self._print_plan(cfg, plan, dry_run=dry_run)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS("\nDry-run complete. No changes written.")
+            )
+            return
+
+        with transaction.atomic():
+            result = self._execute(cfg, plan, actor)
+
+        self._append_audit(cfg, actor, result, dry_run=False)
+
+        if result["client_secret_plaintext"]:
+            self._print_secret_banner(
+                result["client_id"], result["client_secret_plaintext"]
+            )
+        elif result["application_skipped"]:
+            self.stdout.write(
+                self.style.WARNING(
+                    "\nApplication already existed; client_secret was only shown on original creation. "
+                    "If lost, rotate via /cbrt-ops/."
+                )
+            )
+
+        if result["email_user_credentials"]:
+            self._print_email_credentials_banner(result["email_user_credentials"])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nDone. Tenant '{cfg.tenant_code}' provisioned "
+                f"(bindings_created={result['bindings_created']})."
+            )
+        )
+
+    # ---- load / validate ---------------------------------------------------
+
+    def _load_and_validate(self, config_path: Path) -> TenantConfig:
+        if not config_path.exists():
+            raise CommandError(f"Config file not found: {config_path}")
+        try:
+            raw = yaml.safe_load(config_path.read_text())
+        except yaml.YAMLError as e:
+            raise CommandError(f"YAML parse error in {config_path}: {e}")
+        if not isinstance(raw, dict):
+            raise CommandError(
+                f"{config_path}: top-level YAML must be a mapping, got {type(raw).__name__}"
+            )
+        try:
+            return TenantConfig(**raw)
+        except ValidationError as e:
+            lines = ["YAML validation failed:"]
+            for err in e.errors():
+                loc = ".".join(str(p) for p in err["loc"])
+                lines.append(f"  {loc}: {err['msg']}")
+            raise CommandError("\n".join(lines))
+
+    def _resolve_actor(self, email: str) -> User:
+        try:
+            return User.objects.get(email__iexact=email)
+        except User.DoesNotExist:
+            raise CommandError(
+                f"Actor '{email}' has no SSO user. Create yourself via /cbrt-ops/ first."
+            )
+        except User.MultipleObjectsReturned:
+            raise CommandError(
+                f"Multiple users match '{email}' (case-insensitive). "
+                "Deduplicate in /cbrt-ops/ before re-running."
+            )
+
+    # ---- plan --------------------------------------------------------------
+
+    def _build_plan(self, cfg: TenantConfig) -> Dict[str, Any]:
+        slug = self._derive_slug(cfg.tenant_code)
+
+        tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
+        app = Application.objects.filter(name=cfg.application.name).first()
+
+        roles_plan: List[Dict[str, Any]] = []
+        if app:
+            existing_role_codes = set(
+                Role.objects.filter(application=app).values_list("code", flat=True)
+            )
+        else:
+            existing_role_codes = set()
+        for r in cfg.roles:
+            roles_plan.append({"spec": r, "exists": r.code in existing_role_codes})
+
+        users_plan: List[Dict[str, Any]] = []
+        existing_users: Dict[str, User] = {
+            u.email: u
+            for u in User.objects.filter(email__in=[str(u.email) for u in cfg.users])
+        }
+        for u in cfg.users:
+            existing = existing_users.get(str(u.email))
+            mismatch = None
+            if existing is not None and existing.auth_type != u.auth_type:
+                mismatch = f"yaml={u.auth_type}, db={existing.auth_type}"
+            users_plan.append(
+                {
+                    "spec": u,
+                    "exists": existing is not None,
+                    "auth_type_mismatch": mismatch,
+                }
+            )
+
+        bindings_plan: List[Dict[str, Any]] = []
+        for u in cfg.users:
+            user_obj = existing_users.get(str(u.email))
+            role_exists = u.role in existing_role_codes
+            binding_exists = False
+            if app and user_obj and role_exists:
+                role_obj = Role.objects.filter(application=app, code=u.role).first()
+                if role_obj:
+                    binding_exists = UserAppRole.objects.filter(
+                        user=user_obj, role=role_obj, tenant_code=cfg.tenant_code
+                    ).exists()
+            bindings_plan.append(
+                {"email": str(u.email), "role": u.role, "exists": binding_exists}
+            )
+
+        return {
+            "slug": slug,
+            "tenant_exists": tenant is not None,
+            "app_exists": app is not None,
+            "roles": roles_plan,
+            "users": users_plan,
+            "bindings": bindings_plan,
+        }
+
+    def _derive_slug(self, tenant_code: str) -> str:
+        return f"cbrtconnect-{tenant_code.lower()}"
+
+    def _print_plan(
+        self, cfg: TenantConfig, plan: Dict[str, Any], dry_run: bool
+    ) -> None:
+        header = "DRY-RUN PLAN" if dry_run else "PROVISION PLAN"
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(f"\n=== {header}: {cfg.tenant_code} ===")
+        )
+
+        def line(label: str, exists: bool, detail: str = "") -> None:
+            tag = "SKIP (exists)" if exists else "CREATE"
+            style = self.style.WARNING if exists else self.style.SUCCESS
+            suffix = f"  {detail}" if detail else ""
+            self.stdout.write(f"  {style(tag):<25} {label}{suffix}")
+
+        line(
+            f"Tenant {cfg.tenant_code!r} ({cfg.display_name!r})", plan["tenant_exists"]
+        )
+        line(
+            f"Application {cfg.application.name!r} slug={plan['slug']!r}",
+            plan["app_exists"],
+        )
+        for rp in plan["roles"]:
+            line(
+                f"Role {rp['spec'].code!r} (legacy={rp['spec'].legacy_role!r})",
+                rp["exists"],
+            )
+        for up in plan["users"]:
+            detail = f"auth_type={up['spec'].auth_type}"
+            if up["auth_type_mismatch"]:
+                detail += f"  [auth_type mismatch: {up['auth_type_mismatch']} - existing row NOT modified]"
+            line(f"User {str(up['spec'].email)!r}", up["exists"], detail)
+        for bp in plan["bindings"]:
+            line(
+                f"UserAppRole user={bp['email']!r} role={bp['role']!r} tenant={cfg.tenant_code!r}",
+                bp["exists"],
+            )
+
+    # ---- execute -----------------------------------------------------------
+
+    def _execute(
+        self, cfg: TenantConfig, plan: Dict[str, Any], actor: User
+    ) -> Dict[str, Any]:
+        slug = plan["slug"]
+
+        # Tenant
+        Tenant.objects.get_or_create(
+            code=cfg.tenant_code,
+            defaults={"name": cfg.display_name, "is_active": True},
+        )
+
+        # Application
+        app = Application.objects.filter(name=cfg.application.name).first()
+        client_secret_plaintext: str | None = None
+        application_skipped = True
+        if app is None:
+            application_skipped = False
+            client_id = self._gen_unique_client_id()
+            client_secret_plaintext = secrets.token_urlsafe(48)
+            redirect_uris = "\n".join(str(u) for u in cfg.application.redirect_uris)
+            app = Application(
+                name=cfg.application.name,
+                slug=slug,
+                client_id=client_id,
+                client_secret=client_secret_plaintext,
+                redirect_uris=redirect_uris,
+                client_type=Application.CLIENT_CONFIDENTIAL,
+                authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+                user=actor,
+            )
+            app.save()
+
+        # Roles
+        roles_created: List[str] = []
+        role_objs: Dict[str, Role] = {}
+        for r in cfg.roles:
+            role_obj = Role.objects.filter(application=app, code=r.code).first()
+            if role_obj is None:
+                role_obj = Role.objects.create(
+                    application=app,
+                    code=r.code,
+                    name=r.name,
+                    legacy_role=r.legacy_role,
+                    is_active=True,
+                )
+                roles_created.append(r.code)
+            role_objs[r.code] = role_obj
+
+        # Users
+        users_created: List[str] = []
+        user_objs: Dict[str, User] = {}
+        email_user_credentials: List[tuple[str, str]] = []
+        for u in cfg.users:
+            email_str = str(u.email)
+            existing = User.objects.filter(email=email_str).first()
+            if existing is None:
+                if u.auth_type == "email":
+                    temp_password = secrets.token_urlsafe(18)
+                    user_obj = User.objects.create_user(
+                        email=email_str,
+                        password=temp_password,
+                        first_name=u.first_name,
+                        last_name=u.last_name,
+                        display_name=f"{u.first_name} {u.last_name}".strip(),
+                        auth_type="email",
+                        auth_method="password",
+                    )
+                    email_user_credentials.append((email_str, temp_password))
+                else:
+                    user_obj = User.objects.create_user(
+                        email=email_str,
+                        first_name=u.first_name,
+                        last_name=u.last_name,
+                        display_name=f"{u.first_name} {u.last_name}".strip(),
+                        auth_type="google",
+                        auth_method="google",
+                    )
+                users_created.append(email_str)
+            else:
+                user_obj = existing
+            user_objs[email_str] = user_obj
+
+        # Bindings
+        bindings_created = 0
+        for u in cfg.users:
+            email_str = str(u.email)
+            user_obj = user_objs[email_str]
+            role_obj = role_objs[u.role]
+            existing_binding = UserAppRole.objects.filter(
+                user=user_obj, role=role_obj, tenant_code=cfg.tenant_code
+            ).first()
+            if existing_binding is None:
+                UserAppRole.objects.create(
+                    user=user_obj,
+                    role=role_obj,
+                    tenant_code=cfg.tenant_code,
+                    is_active=True,
+                    assigned_by=actor,
+                )
+                bindings_created += 1
+
+        return {
+            "application_id": str(app.id),
+            "application_name": app.name,
+            "application_skipped": application_skipped,
+            "client_id": app.client_id if not application_skipped else None,
+            "client_secret_plaintext": client_secret_plaintext,
+            "roles_created": roles_created,
+            "users_created": users_created,
+            "bindings_created": bindings_created,
+            "email_user_credentials": email_user_credentials,
+        }
+
+    def _gen_unique_client_id(self) -> str:
+        while True:
+            candidate = f"app_{secrets.token_hex(8)}"
+            if not Application.objects.filter(client_id=candidate).exists():
+                return candidate
+
+    # ---- audit / output ----------------------------------------------------
+
+    def _append_audit(
+        self, cfg: TenantConfig, actor: User, result: Dict[str, Any], dry_run: bool
+    ) -> None:
+        record = {
+            "ts": datetime.now(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z"),
+            "actor": actor.email,
+            "tenant_code": cfg.tenant_code,
+            "application_id": result["application_id"],
+            "application_name": result["application_name"],
+            "application_skipped": result["application_skipped"],
+            "roles_created": result["roles_created"],
+            "users_created": result["users_created"],
+            "bindings_created": result["bindings_created"],
+            "dry_run": dry_run,
+        }
+        path = Path(settings.LOGS_DIR) / "tenant_provisioning.jsonl"
+        first_write = not path.exists()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        if first_write:
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
+
+    def _print_secret_banner(self, client_id: str, client_secret: str) -> None:
+        bar = "=" * 64
+        self.stdout.write("\n" + bar)
+        self.stdout.write("COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN")
+        self.stdout.write(bar)
+        self.stdout.write(f"client_id:     {client_id}")
+        self.stdout.write(f"client_secret: {client_secret}")
+        self.stdout.write(bar)
+
+    def _print_email_credentials_banner(
+        self, credentials: List[tuple[str, str]]
+    ) -> None:
+        bar = "=" * 64
+        self.stdout.write("\n" + bar)
+        self.stdout.write("COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN")
+        self.stdout.write(
+            "Email/password users (temp passwords - distribute privately):"
+        )
+        self.stdout.write(bar)
+        email_width = max(len(e) for e, _ in credentials)
+        for email, password in credentials:
+            self.stdout.write(f"  {email:<{email_width}}  {password}")
+        self.stdout.write(bar)
+        self.stdout.write(
+            "Users should change these at https://sso.barge2rail.com/change-password/ on first login."
+        )

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -75,8 +75,10 @@ class Command(BaseCommand):
         with transaction.atomic():
             result = self._execute(cfg, plan, actor)
 
-        self._append_audit(cfg, actor, result, dry_run=False)
-
+        # Banners FIRST — secrets must reach the operator even if audit I/O fails.
+        # DB records are already committed; if we hid the banner behind an I/O
+        # failure, the operator would have a provisioned tenant with no
+        # recoverable client_secret or temp passwords.
         if result["client_secret_plaintext"]:
             self._print_secret_banner(
                 result["client_id"], result["client_secret_plaintext"]
@@ -91,6 +93,19 @@ class Command(BaseCommand):
 
         if result["email_user_credentials"]:
             self._print_email_credentials_banner(result["email_user_credentials"])
+
+        # Audit LAST. Warn-and-continue on I/O failure; provisioning succeeded
+        # and the secrets have been shown, so don't mislead the operator with a
+        # non-zero exit.
+        try:
+            self._append_audit(cfg, actor, result, dry_run=False)
+        except OSError as e:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"Audit log write failed: {e}. "
+                    "Provisioning succeeded; any secrets were displayed above."
+                )
+            )
 
         self.stdout.write(
             self.style.SUCCESS(
@@ -142,6 +157,17 @@ class Command(BaseCommand):
         tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
         app = Application.objects.filter(name=cfg.application.name).first()
 
+        # Finding 3: reject mismatched slug BEFORE any writes (and before
+        # dry-run returns a misleading SKIP plan). Catches copy-paste errors
+        # where tenant_code was changed but application.name was not.
+        if app is not None and app.slug != slug:
+            raise CommandError(
+                f"Application '{cfg.application.name}' already exists with slug "
+                f"'{app.slug}' but this YAML implies slug '{slug}'. "
+                f"Either the tenant_code or the application.name is wrong. "
+                f"Refusing to reuse the existing application."
+            )
+
         roles_plan: List[Dict[str, Any]] = []
         if app:
             existing_role_codes = set(
@@ -152,19 +178,34 @@ class Command(BaseCommand):
         for r in cfg.roles:
             roles_plan.append({"spec": r, "exists": r.code in existing_role_codes})
 
-        users_plan: List[Dict[str, Any]] = []
-        existing_users: Dict[str, User] = {
-            u.email: u
-            for u in User.objects.filter(email__in=[str(u.email) for u in cfg.users])
-        }
+        # Finding 2: normalize emails and look up case-insensitively. A legacy
+        # DB row with mixed-case email matches a lowercase YAML entry; if two
+        # rows differ only by case (historical data), fail fast.
+        existing_users: Dict[str, User] = {}
         for u in cfg.users:
-            existing = existing_users.get(str(u.email))
+            email_str = str(u.email).strip().lower()
+            try:
+                existing = User.objects.get(email__iexact=email_str)
+            except User.DoesNotExist:
+                continue
+            except User.MultipleObjectsReturned:
+                raise CommandError(
+                    f"Multiple users match email '{email_str}' (case-insensitive). "
+                    "Deduplicate in /cbrt-ops/ before re-running."
+                )
+            existing_users[email_str] = existing
+
+        users_plan: List[Dict[str, Any]] = []
+        for u in cfg.users:
+            email_str = str(u.email).strip().lower()
+            existing = existing_users.get(email_str)
             mismatch = None
             if existing is not None and existing.auth_type != u.auth_type:
                 mismatch = f"yaml={u.auth_type}, db={existing.auth_type}"
             users_plan.append(
                 {
                     "spec": u,
+                    "email": email_str,
                     "exists": existing is not None,
                     "auth_type_mismatch": mismatch,
                 }
@@ -172,7 +213,8 @@ class Command(BaseCommand):
 
         bindings_plan: List[Dict[str, Any]] = []
         for u in cfg.users:
-            user_obj = existing_users.get(str(u.email))
+            email_str = str(u.email).strip().lower()
+            user_obj = existing_users.get(email_str)
             role_exists = u.role in existing_role_codes
             binding_exists = False
             if app and user_obj and role_exists:
@@ -182,7 +224,7 @@ class Command(BaseCommand):
                         user=user_obj, role=role_obj, tenant_code=cfg.tenant_code
                     ).exists()
             bindings_plan.append(
-                {"email": str(u.email), "role": u.role, "exists": binding_exists}
+                {"email": email_str, "role": u.role, "exists": binding_exists}
             )
 
         return {
@@ -227,7 +269,7 @@ class Command(BaseCommand):
             detail = f"auth_type={up['spec'].auth_type}"
             if up["auth_type_mismatch"]:
                 detail += f"  [auth_type mismatch: {up['auth_type_mismatch']} - existing row NOT modified]"
-            line(f"User {str(up['spec'].email)!r}", up["exists"], detail)
+            line(f"User {up['email']!r}", up["exists"], detail)
         for bp in plan["bindings"]:
             line(
                 f"UserAppRole user={bp['email']!r} role={bp['role']!r} tenant={cfg.tenant_code!r}",
@@ -284,13 +326,15 @@ class Command(BaseCommand):
                 roles_created.append(r.code)
             role_objs[r.code] = role_obj
 
-        # Users
+        # Users — emails are normalized to lowercase on creation, and
+        # existence checks are case-insensitive so a legacy mixed-case DB row
+        # still matches a lowercase YAML entry.
         users_created: List[str] = []
         user_objs: Dict[str, User] = {}
         email_user_credentials: List[tuple[str, str]] = []
         for u in cfg.users:
-            email_str = str(u.email)
-            existing = User.objects.filter(email=email_str).first()
+            email_str = str(u.email).strip().lower()
+            existing = User.objects.filter(email__iexact=email_str).first()
             if existing is None:
                 if u.auth_type == "email":
                     temp_password = secrets.token_urlsafe(18)
@@ -321,7 +365,7 @@ class Command(BaseCommand):
         # Bindings
         bindings_created = 0
         for u in cfg.users:
-            email_str = str(u.email)
+            email_str = str(u.email).strip().lower()
             user_obj = user_objs[email_str]
             role_obj = role_objs[u.role]
             existing_binding = UserAppRole.objects.filter(

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -1,0 +1,457 @@
+"""Tests for the provision_tenant management command."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+from sso.models import Application, Role, Tenant, User, UserAppRole
+
+VALID_YAML = """
+tenant_code: TSTP
+display_name: "Test Provision"
+
+application:
+  name: "CBRTConnect - TSTP"
+  redirect_uris:
+    - https://example.com/oauth/callback/
+
+roles:
+  - code: cbrtconnect_tstp_admin
+    name: "CBRTConnect TSTP Admin"
+    legacy_role: Admin
+  - code: cbrtconnect_tstp_viewer
+    name: "CBRTConnect TSTP Viewer"
+    legacy_role: Client
+
+users:
+  - email: alice@tstp.example.com
+    first_name: Alice
+    last_name: Anderson
+    role: cbrtconnect_tstp_admin
+    auth_type: google
+  - email: bob@tstp.example.com
+    first_name: Bob
+    last_name: Brown
+    role: cbrtconnect_tstp_viewer
+    auth_type: google
+"""
+
+
+def _yaml_with_users(users_block: str) -> str:
+    """Build a YAML with a single role and a custom users block (indented correctly)."""
+    return (
+        "tenant_code: TSTE\n"
+        'display_name: "Test Email"\n'
+        "application:\n"
+        '  name: "CBRTConnect - TSTE"\n'
+        "  redirect_uris:\n"
+        "    - https://example.com/oauth/callback/\n"
+        "roles:\n"
+        "  - code: cbrtconnect_tste_client\n"
+        '    name: "CBRTConnect TSTE Client"\n'
+        "    legacy_role: Client\n"
+        "users:\n" + users_block
+    )
+
+
+class ProvisionTenantTestBase(TestCase):
+    """Shared setup: temp dir for YAML + audit file, actor user."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp_path = Path(self._tmp.name)
+        self.audit_override = override_settings(LOGS_DIR=self.tmp_path)
+        self.audit_override.enable()
+        self.addCleanup(self.audit_override.disable)
+
+        self.actor = User.objects.create_user(
+            email="clif@barge2rail.com",
+            first_name="Clif",
+            last_name="Badante",
+            auth_type="google",
+            auth_method="google",
+        )
+
+    def _write_yaml(self, content: str, name: str = "tenant.yaml") -> str:
+        p = self.tmp_path / name
+        p.write_text(content)
+        return str(p)
+
+    def _run(self, *args, expect_success: bool = True) -> str:
+        out, err = StringIO(), StringIO()
+        try:
+            call_command("provision_tenant", *args, stdout=out, stderr=err)
+        except CommandError:
+            if expect_success:
+                raise
+            raise
+        return out.getvalue()
+
+    def _audit_lines(self) -> list[dict]:
+        path = self.tmp_path / "tenant_provisioning.jsonl"
+        if not path.exists():
+            return []
+        return [
+            json.loads(line) for line in path.read_text().splitlines() if line.strip()
+        ]
+
+
+class DryRunTests(ProvisionTenantTestBase):
+    def test_dry_run_creates_nothing(self):
+        cfg = self._write_yaml(VALID_YAML)
+        out = self._run("--config", cfg, "--dry-run")
+
+        self.assertEqual(Application.objects.count(), 0)
+        self.assertEqual(Role.objects.count(), 0)
+        # Only users that should exist: the actor we created in setUp plus
+        # any seeded by migrations. Neither of the YAML's users should exist.
+        self.assertEqual(
+            User.objects.filter(
+                email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
+            ).count(),
+            0,
+        )
+        self.assertEqual(UserAppRole.objects.count(), 0)
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+        self.assertIn("CREATE", out)
+        self.assertIn("DRY-RUN PLAN", out)
+        self.assertEqual(self._audit_lines(), [])
+
+
+class HappyPathTests(ProvisionTenantTestBase):
+    def test_happy_path_creates_everything(self):
+        cfg = self._write_yaml(VALID_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTP").count(), 1
+        )
+        app = Application.objects.get(name="CBRTConnect - TSTP")
+        self.assertEqual(app.slug, "cbrtconnect-tstp")
+        self.assertEqual(app.user, self.actor)
+
+        self.assertEqual(Role.objects.filter(application=app).count(), 2)
+        self.assertEqual(
+            User.objects.filter(
+                email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
+            ).count(),
+            2,
+        )
+        self.assertEqual(UserAppRole.objects.filter(tenant_code="TSTP").count(), 2)
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 1)
+
+        alice = User.objects.get(email="alice@tstp.example.com")
+        self.assertEqual(alice.auth_type, "google")
+        self.assertFalse(alice.has_usable_password())
+
+        self.assertIn("COPY THIS NOW", out)
+        self.assertIn(app.client_id, out)
+
+        audit = self._audit_lines()
+        self.assertEqual(len(audit), 1)
+        rec = audit[0]
+        self.assertEqual(rec["tenant_code"], "TSTP")
+        self.assertEqual(rec["actor"], "clif@barge2rail.com")
+        self.assertEqual(
+            sorted(rec["users_created"]),
+            ["alice@tstp.example.com", "bob@tstp.example.com"],
+        )
+        self.assertEqual(rec["bindings_created"], 2)
+        self.assertNotIn("client_secret", rec)
+        self.assertNotIn("client_id", rec)
+
+
+class IdempotencyTests(ProvisionTenantTestBase):
+    def test_idempotent_rerun(self):
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        app_count = Application.objects.count()
+        role_count = Role.objects.count()
+        user_count = User.objects.count()
+        binding_count = UserAppRole.objects.count()
+
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        self.assertEqual(Application.objects.count(), app_count)
+        self.assertEqual(Role.objects.count(), role_count)
+        self.assertEqual(User.objects.count(), user_count)
+        self.assertEqual(UserAppRole.objects.count(), binding_count)
+        self.assertIn("SKIP (exists)", out)
+        self.assertNotIn("COPY THIS NOW", out)
+
+        audit = self._audit_lines()
+        self.assertEqual(len(audit), 2)
+        self.assertEqual(audit[1]["bindings_created"], 0)
+        self.assertTrue(audit[1]["application_skipped"])
+
+
+class ValidationTests(ProvisionTenantTestBase):
+    def test_invalid_yaml_missing_field(self):
+        bad = VALID_YAML.replace("tenant_code: TSTP\n", "")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("tenant_code", str(ctx.exception))
+
+    def test_invalid_role_reference(self):
+        bad = VALID_YAML.replace(
+            "role: cbrtconnect_tstp_admin", "role: cbrtconnect_tstp_ghost"
+        )
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("cbrtconnect_tstp_ghost", msg)
+
+    def test_invalid_tenant_code(self):
+        bad = VALID_YAML.replace("tenant_code: TSTP", "tenant_code: tstp-bad")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("tenant_code", str(ctx.exception))
+
+
+class ActorTests(ProvisionTenantTestBase):
+    def test_missing_actor_real_run(self):
+        cfg = self._write_yaml(VALID_YAML)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg)
+        self.assertIn("--actor", str(ctx.exception))
+
+    def test_actor_with_dry_run_rejected(self):
+        cfg = self._write_yaml(VALID_YAML)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--dry-run", "--actor", "clif@barge2rail.com")
+        self.assertIn("--actor", str(ctx.exception))
+
+    def test_unknown_actor(self):
+        cfg = self._write_yaml(VALID_YAML)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "ghost@barge2rail.com")
+        self.assertIn("ghost@barge2rail.com", str(ctx.exception))
+
+    def test_actor_case_insensitive(self):
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "CLIF@BARGE2RAIL.COM")
+        app = Application.objects.get(name="CBRTConnect - TSTP")
+        self.assertEqual(app.user, self.actor)
+
+
+class RollbackTests(ProvisionTenantTestBase):
+    def test_rollback_on_mid_transaction_failure(self):
+        cfg = self._write_yaml(VALID_YAML)
+        call_count = {"n": 0}
+        real_save = UserAppRole.save
+
+        def boom(self, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("simulated DB failure")
+            return real_save(self, *args, **kwargs)
+
+        with mock.patch.object(UserAppRole, "save", boom):
+            with self.assertRaises(RuntimeError):
+                self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        # All writes rolled back
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTP").count(), 0
+        )
+        self.assertEqual(Role.objects.count(), 0)
+        self.assertEqual(
+            User.objects.filter(
+                email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
+            ).count(),
+            0,
+        )
+        self.assertEqual(UserAppRole.objects.count(), 0)
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+
+        # No audit line written (audit happens after successful commit)
+        self.assertEqual(self._audit_lines(), [])
+
+
+class EmailAuthTests(ProvisionTenantTestBase):
+    """Tests for the auth_type: email user creation path."""
+
+    EMAIL_USER_YAML = _yaml_with_users(
+        "  - email: briana@marianshipping.example.com\n"
+        "    first_name: Briana\n"
+        "    last_name: Jackson\n"
+        "    role: cbrtconnect_tste_client\n"
+        "    auth_type: email\n"
+    )
+
+    GOOGLE_USER_YAML = _yaml_with_users(
+        "  - email: staff@barge2rail.com\n"
+        "    first_name: Staff\n"
+        "    last_name: Person\n"
+        "    role: cbrtconnect_tste_client\n"
+        "    auth_type: google\n"
+    )
+
+    DEFAULT_AUTH_YAML = _yaml_with_users(
+        "  - email: noauth@example.com\n"
+        "    first_name: Default\n"
+        "    last_name: Auth\n"
+        "    role: cbrtconnect_tste_client\n"
+        # auth_type omitted on purpose
+    )
+
+    MIXED_YAML = _yaml_with_users(
+        "  - email: briana@marianshipping.example.com\n"
+        "    first_name: Briana\n"
+        "    last_name: Jackson\n"
+        "    role: cbrtconnect_tste_client\n"
+        "    auth_type: email\n"
+        "  - email: staff@barge2rail.com\n"
+        "    first_name: Staff\n"
+        "    last_name: Person\n"
+        "    role: cbrtconnect_tste_client\n"
+        "    auth_type: google\n"
+    )
+
+    ANON_YAML = _yaml_with_users(
+        "  - email: anon@example.com\n"
+        "    first_name: Anon\n"
+        "    last_name: User\n"
+        "    role: cbrtconnect_tste_client\n"
+        "    auth_type: anonymous\n"
+    )
+
+    @staticmethod
+    def _extract_password_for(stdout: str, email: str) -> str:
+        """Find the password printed next to an email in the credentials banner."""
+        for raw in stdout.splitlines():
+            stripped = raw.strip()
+            if stripped.startswith(email):
+                parts = stripped.split()
+                # Line format: "<email>  <password>"
+                if len(parts) >= 2:
+                    return parts[-1]
+        raise AssertionError(f"No password line found for {email!r} in stdout")
+
+    def test_email_user_gets_temp_password(self):
+        cfg = self._write_yaml(self.EMAIL_USER_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        user = User.objects.get(email="briana@marianshipping.example.com")
+        self.assertEqual(user.auth_type, "email")
+        self.assertEqual(user.auth_method, "password")
+        self.assertTrue(user.has_usable_password())
+
+        self.assertIn("briana@marianshipping.example.com", out)
+        self.assertIn("Email/password users", out)
+        temp_password = self._extract_password_for(
+            out, "briana@marianshipping.example.com"
+        )
+        self.assertGreaterEqual(len(temp_password), 20)  # token_urlsafe(18) ~= 24 chars
+        self.assertTrue(user.check_password(temp_password))
+
+    def test_email_user_password_not_in_audit(self):
+        cfg = self._write_yaml(self.EMAIL_USER_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        temp_password = self._extract_password_for(
+            out, "briana@marianshipping.example.com"
+        )
+
+        audit_path = self.tmp_path / "tenant_provisioning.jsonl"
+        audit_content = audit_path.read_text()
+        self.assertNotIn(temp_password, audit_content)
+        # Defense-in-depth: field names that would leak secrets
+        self.assertNotIn("temp_password", audit_content)
+        self.assertNotIn("password", audit_content)
+
+    def test_google_user_unchanged(self):
+        cfg = self._write_yaml(self.GOOGLE_USER_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        user = User.objects.get(email="staff@barge2rail.com")
+        self.assertEqual(user.auth_type, "google")
+        self.assertEqual(user.auth_method, "google")
+        self.assertFalse(user.has_usable_password())
+        self.assertNotIn("Email/password users", out)
+
+    def test_mixed_yaml_both_auth_types(self):
+        cfg = self._write_yaml(self.MIXED_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        briana = User.objects.get(email="briana@marianshipping.example.com")
+        staff = User.objects.get(email="staff@barge2rail.com")
+        self.assertEqual(briana.auth_type, "email")
+        self.assertTrue(briana.has_usable_password())
+        self.assertEqual(staff.auth_type, "google")
+        self.assertFalse(staff.has_usable_password())
+
+        # Credentials banner lists only the email user
+        self.assertIn("Email/password users", out)
+        banner_section = out.split("Email/password users", 1)[1]
+        self.assertIn("briana@marianshipping.example.com", banner_section)
+        self.assertNotIn("staff@barge2rail.com", banner_section)
+
+    def test_default_auth_type_is_email(self):
+        cfg = self._write_yaml(self.DEFAULT_AUTH_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        user = User.objects.get(email="noauth@example.com")
+        self.assertEqual(user.auth_type, "email")
+        self.assertTrue(user.has_usable_password())
+        self.assertIn("noauth@example.com", out)
+
+    def test_anonymous_auth_type_rejected(self):
+        cfg = self._write_yaml(self.ANON_YAML)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("auth_type", msg)
+        self.assertIn("anonymous", msg)
+        self.assertIn("users.0.auth_type", msg)
+        # Nothing should have been created
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTE").count(), 0
+        )
+
+    def test_existing_google_user_skipped_with_mismatch_warning(self):
+        User.objects.create_user(
+            email="briana@marianshipping.example.com",
+            first_name="Briana",
+            last_name="Jackson",
+            auth_type="google",
+            auth_method="google",
+        )
+        cfg = self._write_yaml(self.EMAIL_USER_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        self.assertIn("auth_type mismatch", out)
+        user = User.objects.get(email="briana@marianshipping.example.com")
+        # Existing auth_type preserved, not clobbered
+        self.assertEqual(user.auth_type, "google")
+        self.assertFalse(user.has_usable_password())
+        # No temp password printed for a SKIP'd user
+        banner_split = out.split("Email/password users")
+        if len(banner_split) > 1:
+            self.assertNotIn("briana@marianshipping.example.com", banner_split[1])
+
+    def test_idempotent_rerun_email_user(self):
+        cfg = self._write_yaml(self.EMAIL_USER_YAML)
+        out1 = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        original_password = self._extract_password_for(
+            out1, "briana@marianshipping.example.com"
+        )
+
+        out2 = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        self.assertNotIn("Email/password users", out2)
+        user = User.objects.get(email="briana@marianshipping.example.com")
+        # Password not rotated on re-run
+        self.assertTrue(user.check_password(original_password))

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -455,3 +455,208 @@ class EmailAuthTests(ProvisionTenantTestBase):
         user = User.objects.get(email="briana@marianshipping.example.com")
         # Password not rotated on re-run
         self.assertTrue(user.check_password(original_password))
+
+
+class AuditFailureTests(ProvisionTenantTestBase):
+    """Codex finding 1: banner must print even if audit I/O fails."""
+
+    def test_audit_failure_does_not_block_banner(self):
+        cfg = self._write_yaml(EmailAuthTests.EMAIL_USER_YAML)
+
+        out, err = StringIO(), StringIO()
+        from sso.management.commands.provision_tenant import Command
+
+        with mock.patch.object(
+            Command, "_append_audit", side_effect=OSError("disk full simulation")
+        ):
+            # Must NOT raise — secrets were already shown.
+            call_command(
+                "provision_tenant",
+                "--config",
+                cfg,
+                "--actor",
+                "clif@barge2rail.com",
+                stdout=out,
+                stderr=err,
+            )
+
+        stdout_text = out.getvalue()
+        stderr_text = err.getvalue()
+
+        # Both banners printed before the audit failure
+        self.assertIn("COPY THIS NOW", stdout_text)
+        self.assertIn("briana@marianshipping.example.com", stdout_text)
+
+        # Warning about audit failure landed on stderr
+        self.assertIn("Audit log write failed", stderr_text)
+        self.assertIn("disk full simulation", stderr_text)
+
+        # DB side effects succeeded
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTE").count(), 1
+        )
+        self.assertEqual(
+            User.objects.filter(email="briana@marianshipping.example.com").count(), 1
+        )
+        self.assertEqual(UserAppRole.objects.count(), 1)
+
+
+class EmailNormalizationTests(ProvisionTenantTestBase):
+    """Codex finding 2: email lookups must be case-insensitive and stored lowercased."""
+
+    def test_email_case_normalization_on_create(self):
+        yaml_content = _yaml_with_users(
+            "  - email: TestUser@Example.COM\n"
+            "    first_name: Test\n"
+            "    last_name: User\n"
+            "    role: cbrtconnect_tste_client\n"
+            "    auth_type: google\n"
+        )
+        cfg = self._write_yaml(yaml_content)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        # Stored lowercase
+        self.assertEqual(User.objects.filter(email="testuser@example.com").count(), 1)
+        self.assertEqual(User.objects.filter(email="TestUser@Example.COM").count(), 0)
+
+        # Plan output shows normalized form
+        self.assertIn("testuser@example.com", out)
+
+        # Audit records the normalized email
+        audit = self._audit_lines()
+        self.assertEqual(audit[0]["users_created"], ["testuser@example.com"])
+
+    def test_email_case_insensitive_idempotency(self):
+        base_users = (
+            "  - email: alice@example.com\n"
+            "    first_name: Alice\n"
+            "    last_name: Case\n"
+            "    role: cbrtconnect_tste_client\n"
+            "    auth_type: google\n"
+        )
+        yaml1 = _yaml_with_users(base_users)
+        yaml2 = _yaml_with_users(base_users.replace("alice", "Alice", 1))
+
+        cfg1 = self._write_yaml(yaml1, name="yaml1.yaml")
+        self._run("--config", cfg1, "--actor", "clif@barge2rail.com")
+
+        cfg2 = self._write_yaml(yaml2, name="yaml2.yaml")
+        out = self._run("--config", cfg2, "--actor", "clif@barge2rail.com")
+
+        # Second run should SKIP the existing user
+        self.assertIn("SKIP (exists)", out)
+        self.assertEqual(
+            User.objects.filter(email__iexact="alice@example.com").count(), 1
+        )
+        # Exactly one binding — no duplicate
+        self.assertEqual(UserAppRole.objects.count(), 1)
+
+    def test_multiple_users_same_email_different_case(self):
+        # Simulate legacy data: two rows that differ only by case. User.objects.create()
+        # bypasses the UserManager convenience but still runs save() which auto-
+        # generates username from email (case-preserved), so both rows satisfy
+        # the case-sensitive unique constraint at the DB level.
+        u1 = User(
+            email="bob@example.com",
+            first_name="Bob",
+            last_name="Lower",
+            auth_type="google",
+            auth_method="google",
+        )
+        u1.set_unusable_password()
+        u1.save()
+        u2 = User(
+            email="Bob@example.com",
+            first_name="Bob",
+            last_name="Upper",
+            auth_type="google",
+            auth_method="google",
+        )
+        u2.set_unusable_password()
+        u2.save()
+
+        yaml_content = _yaml_with_users(
+            "  - email: bob@example.com\n"
+            "    first_name: Bob\n"
+            "    last_name: Builder\n"
+            "    role: cbrtconnect_tste_client\n"
+            "    auth_type: google\n"
+        )
+        cfg = self._write_yaml(yaml_content)
+
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        msg = str(ctx.exception)
+        self.assertIn("Multiple users", msg)
+        self.assertIn("bob@example.com", msg)
+
+        # Nothing else created
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTE").count(), 0
+        )
+        self.assertEqual(Role.objects.count(), 0)
+        self.assertEqual(UserAppRole.objects.count(), 0)
+        self.assertEqual(Tenant.objects.filter(code="TSTE").count(), 0)
+
+
+class ApplicationSlugMismatchTests(ProvisionTenantTestBase):
+    """Codex finding 3: reusing an Application by name must verify slug match."""
+
+    YAML_MSP = """
+tenant_code: MSP
+display_name: "Marian Shipping"
+
+application:
+  name: "CBRTConnect - MSP"
+  redirect_uris:
+    - https://example.com/oauth/callback/
+
+roles:
+  - code: cbrtconnect_msp_admin
+    name: "CBRTConnect MSP Admin"
+    legacy_role: Admin
+
+users:
+  - email: admin@example.com
+    first_name: Ad
+    last_name: Min
+    role: cbrtconnect_msp_admin
+    auth_type: google
+"""
+
+    def _preexisting_mismatched_app(self) -> Application:
+        return Application.objects.create(
+            name="CBRTConnect - MSP",
+            slug="cbrtconnect-opt",  # wrong tenant's slug (copy-paste error)
+            client_id="app_existing",
+            client_secret="existing-secret",  # pragma: allowlist secret
+            redirect_uris="https://example.com/oauth/callback/",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.actor,
+        )
+
+    def test_application_slug_mismatch_rejected(self):
+        self._preexisting_mismatched_app()
+        cfg = self._write_yaml(self.YAML_MSP)
+
+        # Real run must reject with both slugs named in the error.
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("cbrtconnect-opt", msg)
+        self.assertIn("cbrtconnect-msp", msg)
+
+        # Dry-run must reject with the same mismatch (plan-time check, not execute-time).
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--dry-run")
+        msg = str(ctx.exception)
+        self.assertIn("cbrtconnect-opt", msg)
+        self.assertIn("cbrtconnect-msp", msg)
+
+        # No DB writes from either attempt.
+        self.assertEqual(Role.objects.count(), 0)
+        self.assertEqual(UserAppRole.objects.count(), 0)
+        self.assertEqual(Tenant.objects.filter(code="MSP").count(), 0)
+        self.assertEqual(User.objects.filter(email="admin@example.com").count(), 0)

--- a/tenants/.gitignore
+++ b/tenants/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!_template.yaml

--- a/tenants/_template.yaml
+++ b/tenants/_template.yaml
@@ -1,0 +1,58 @@
+# Tenant provisioning template.
+#
+# Copy this file to tenants/<tenant_code>.yaml (e.g. tenants/msp.yaml), fill in
+# real values, then run:
+#
+#   python manage.py provision_tenant --config tenants/<file>.yaml --dry-run
+#   python manage.py provision_tenant --config tenants/<file>.yaml --actor you@barge2rail.com
+#
+# DO NOT commit the filled-in file. tenants/.gitignore ignores everything
+# except this template. The YAML may contain user PII (emails, names).
+
+tenant_code: XXX                                  # 1-10 chars, uppercase alphanumeric (MSP, OPT, HLR...)
+display_name: "Full Tenant Name"                  # used for the Tenant reference row
+
+application:
+  name: "CBRTConnect - XXX"                       # unique across all SSO apps
+  redirect_uris:
+    - https://cbrtconnect.com/oauth/callback/
+    - https://dev.cbrtconnect.com/oauth/callback/
+
+# Roles created on the new Application. legacy_role is what client apps read
+# from the JWT (application_roles.<slug>.role). The code is machine-readable
+# and must be unique within this application.
+roles:
+  - code: cbrtconnect_xxx_admin
+    name: "CBRTConnect XXX Admin"
+    legacy_role: Admin
+  - code: cbrtconnect_xxx_operator
+    name: "CBRTConnect XXX Operator"
+    legacy_role: Operator
+  - code: cbrtconnect_xxx_viewer
+    name: "CBRTConnect XXX Viewer"
+    legacy_role: Client
+
+# Users bound to roles under this tenant. One role per user per run;
+# add another YAML entry to give a user multiple roles.
+#
+# auth_type: "email" (default) or "google".
+#   - email   → user gets a temp password (printed once at end of real run)
+#                that they change at https://sso.barge2rail.com/change-password/.
+#                Use for tenant client users who are NOT Google Workspace accounts.
+#   - google  → user signs in via Google OAuth; no password is set. Use for
+#                barge2rail staff on @barge2rail.com.
+#   - anonymous → NOT supported by provision_tenant. Create via /cbrt-ops/.
+users:
+  # Example email/password user (the common case for tenant clients):
+  - email: contact@example.com
+    first_name: First
+    last_name: Last
+    role: cbrtconnect_xxx_admin
+    auth_type: email
+
+  # Example Google OAuth user (staff on barge2rail.com):
+  # - email: staff@barge2rail.com
+  #   first_name: Staff
+  #   last_name: Member
+  #   role: cbrtconnect_xxx_admin
+  #   auth_type: google


### PR DESCRIPTION
Adds a Django management command that creates Tenant, Application, Roles, Users, and UserAppRole bindings atomically from a YAML config file.

Features:
- Transactional (all-or-nothing) with --dry-run preview
- Idempotent (SKIP existing records on re-run, no duplicates)
- Supports both email/password and Google OAuth users
- Generates cryptographic temp passwords for email users
- One-time secret banner for client_secret and temp passwords
- Audit log to logs/tenant_provisioning.jsonl (no secrets)
- 19 tests covering happy path, idempotency, validation, security

Verified end-to-end on dev against TESTPROV and TESTEMAIL tenants.