### PR TITLE
feat(provision_tenant): optional application.slug YAML field

### DIFF
--- a/docs/tenant-onboarding.md
+++ b/docs/tenant-onboarding.md
@@ -62,7 +62,7 @@ existing prod convention for tenants like `primetrade`, `sacks`, `msp`. Override
 when you need a specific slug (e.g., `cbrtconnect-dev` for a dev-only app).
 
 Must be lowercase alphanumeric with hyphens. No underscores, no uppercase, no
-leading/trailing hyphens. 2-64 characters.
+leading/trailing hyphens. 2-50 characters (matches `Application.slug` DB field).
 
 **Do not commit the filled-in YAML.** `tenants/.gitignore` blocks everything except
 `_template.yaml`. Keep the filled YAML locally or in 1Password — it contains user PII.

--- a/docs/tenant-onboarding.md
+++ b/docs/tenant-onboarding.md
@@ -52,7 +52,17 @@ Edit `tenants/msp.yaml`:
     for `@barge2rail.com` staff.
   - `anonymous` — not supported by `provision_tenant`. Create via `/cbrt-ops/`.
 
-The Application `slug` is auto-derived as `cbrtconnect-<tenant_code.lower()>`.
+### `application.slug` (optional)
+
+URL-safe identifier for the Application. Used in JWT claims as
+`application_roles.<slug>.tenant_code` / `application_roles.<slug>.role`.
+
+If omitted, defaults to `tenant_code.lower()` (bare slug) — matching the
+existing prod convention for tenants like `primetrade`, `sacks`, `msp`. Override
+when you need a specific slug (e.g., `cbrtconnect-dev` for a dev-only app).
+
+Must be lowercase alphanumeric with hyphens. No underscores, no uppercase, no
+leading/trailing hyphens. 2-64 characters.
 
 **Do not commit the filled-in YAML.** `tenants/.gitignore` blocks everything except
 `_template.yaml`. Keep the filled YAML locally or in 1Password — it contains user PII.

--- a/sso/management/commands/_tenant_schema.py
+++ b/sso/management/commands/_tenant_schema.py
@@ -19,6 +19,10 @@ from pydantic import (
 )
 
 TENANT_CODE_RE = re.compile(r"^[A-Z0-9]{1,10}$")
+# Django-style slug: lowercase alphanumeric + hyphens, no leading/trailing
+# hyphens, 2-64 chars. Matches the existing prod convention (primetrade,
+# cbrtconnect-dev, etc.).
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$")
 # Pragmatic email regex: good enough to catch typos in hand-written YAML.
 # Deep RFC 5322 conformance would require the email-validator package (not a
 # current dep) and is overkill for a human-reviewed config file.
@@ -69,7 +73,25 @@ class ApplicationSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(min_length=1, max_length=255)
+    # Optional. When omitted, the command layer defaults to tenant_code.lower()
+    # (bare slug), matching the existing prod convention. When provided,
+    # operators can override for any reason (legacy rename, special casing, etc.)
+    slug: str | None = None
     redirect_uris: List[HttpUrl] = Field(min_length=1)
+
+    @field_validator("slug")
+    @classmethod
+    def _check_slug(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not SLUG_RE.match(v):
+            raise ValueError(
+                "slug must be lowercase alphanumeric with hyphens, "
+                "e.g. 'msp' or 'cbrtconnect-dev' "
+                "(no uppercase, no underscores, no leading/trailing hyphens, "
+                "2-64 chars)"
+            )
+        return v
 
 
 class TenantConfig(BaseModel):

--- a/sso/management/commands/_tenant_schema.py
+++ b/sso/management/commands/_tenant_schema.py
@@ -20,9 +20,10 @@ from pydantic import (
 
 TENANT_CODE_RE = re.compile(r"^[A-Z0-9]{1,10}$")
 # Django-style slug: lowercase alphanumeric + hyphens, no leading/trailing
-# hyphens, 2-64 chars. Matches the existing prod convention (primetrade,
-# cbrtconnect-dev, etc.).
-SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$")
+# hyphens, 2-50 chars. Matches the existing prod convention (primetrade,
+# cbrtconnect-dev, etc.) and the Application.slug SlugField(max_length=50)
+# constraint. Fail fast here rather than blowing up at Application.save().
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$")
 # Pragmatic email regex: good enough to catch typos in hand-written YAML.
 # Deep RFC 5322 conformance would require the email-validator package (not a
 # current dep) and is overkill for a human-reviewed config file.
@@ -89,7 +90,7 @@ class ApplicationSpec(BaseModel):
                 "slug must be lowercase alphanumeric with hyphens, "
                 "e.g. 'msp' or 'cbrtconnect-dev' "
                 "(no uppercase, no underscores, no leading/trailing hyphens, "
-                "2-64 chars)"
+                "2-50 chars)"
             )
         return v
 

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
     # ---- plan --------------------------------------------------------------
 
     def _build_plan(self, cfg: TenantConfig) -> Dict[str, Any]:
-        slug = self._derive_slug(cfg.tenant_code)
+        slug = cfg.application.slug or cfg.tenant_code.lower()
 
         tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
         app = Application.objects.filter(name=cfg.application.name).first()
@@ -161,11 +161,17 @@ class Command(BaseCommand):
         # dry-run returns a misleading SKIP plan). Catches copy-paste errors
         # where tenant_code was changed but application.name was not.
         if app is not None and app.slug != slug:
+            if cfg.application.slug is not None:
+                implication = f"YAML specifies slug '{slug}'"
+            else:
+                implication = (
+                    f"this YAML implies slug '{slug}' (derived from tenant_code)"
+                )
             raise CommandError(
                 f"Application '{cfg.application.name}' already exists with slug "
-                f"'{app.slug}' but this YAML implies slug '{slug}'. "
-                f"Either the tenant_code or the application.name is wrong. "
-                f"Refusing to reuse the existing application."
+                f"'{app.slug}' but {implication}. "
+                f"Either the tenant_code, application.name, or application.slug "
+                f"is wrong. Refusing to reuse the existing application."
             )
 
         roles_plan: List[Dict[str, Any]] = []
@@ -235,9 +241,6 @@ class Command(BaseCommand):
             "users": users_plan,
             "bindings": bindings_plan,
         }
-
-    def _derive_slug(self, tenant_code: str) -> str:
-        return f"cbrtconnect-{tenant_code.lower()}"
 
     def _print_plan(
         self, cfg: TenantConfig, plan: Dict[str, Any], dry_run: bool

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -174,6 +174,19 @@ class Command(BaseCommand):
                 f"is wrong. Refusing to reuse the existing application."
             )
 
+        # Slug is unique across Applications. If no app matched by name but
+        # some other Application already owns this slug, fail at plan time
+        # with an actionable error instead of an IntegrityError from _execute.
+        if app is None:
+            slug_conflict = Application.objects.filter(slug=slug).first()
+            if slug_conflict is not None:
+                raise CommandError(
+                    f"Slug '{slug}' is already in use by a different Application "
+                    f"'{slug_conflict.name}'. "
+                    f"Choose a different application.slug or resolve via /cbrt-ops/. "
+                    f"Refusing to create a second Application with the same slug."
+                )
+
         roles_plan: List[Dict[str, Any]] = []
         if app:
             existing_role_codes = set(

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -136,7 +136,7 @@ class HappyPathTests(ProvisionTenantTestBase):
             Application.objects.filter(name="CBRTConnect - TSTP").count(), 1
         )
         app = Application.objects.get(name="CBRTConnect - TSTP")
-        self.assertEqual(app.slug, "cbrtconnect-tstp")
+        self.assertEqual(app.slug, "tstp")
         self.assertEqual(app.user, self.actor)
 
         self.assertEqual(Role.objects.filter(application=app).count(), 2)
@@ -628,7 +628,7 @@ users:
     def _preexisting_mismatched_app(self) -> Application:
         return Application.objects.create(
             name="CBRTConnect - MSP",
-            slug="cbrtconnect-opt",  # wrong tenant's slug (copy-paste error)
+            slug="opt",  # wrong tenant's slug (copy-paste error)
             client_id="app_existing",
             client_secret="existing-secret",  # pragma: allowlist secret
             redirect_uris="https://example.com/oauth/callback/",
@@ -645,18 +645,110 @@ users:
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         msg = str(ctx.exception)
-        self.assertIn("cbrtconnect-opt", msg)
-        self.assertIn("cbrtconnect-msp", msg)
+        self.assertIn("'opt'", msg)
+        self.assertIn("'msp'", msg)
 
         # Dry-run must reject with the same mismatch (plan-time check, not execute-time).
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--dry-run")
         msg = str(ctx.exception)
-        self.assertIn("cbrtconnect-opt", msg)
-        self.assertIn("cbrtconnect-msp", msg)
+        self.assertIn("'opt'", msg)
+        self.assertIn("'msp'", msg)
 
         # No DB writes from either attempt.
         self.assertEqual(Role.objects.count(), 0)
         self.assertEqual(UserAppRole.objects.count(), 0)
         self.assertEqual(Tenant.objects.filter(code="MSP").count(), 0)
         self.assertEqual(User.objects.filter(email="admin@example.com").count(), 0)
+
+
+class ApplicationSlugOverrideTests(ProvisionTenantTestBase):
+    """Optional application.slug field: defaults to tenant_code.lower(),
+    operators may override, schema-level validation rejects invalid values."""
+
+    @staticmethod
+    def _yaml(slug_line: str = "") -> str:
+        """Build a valid YAML with an optional slug line under application:."""
+        return (
+            "tenant_code: TSTS\n"
+            'display_name: "Test Slug"\n'
+            "application:\n"
+            '  name: "CBRTConnect - TSTS"\n'
+            f"{slug_line}"
+            "  redirect_uris:\n"
+            "    - https://example.com/oauth/callback/\n"
+            "roles:\n"
+            "  - code: cbrtconnect_tsts_admin\n"
+            '    name: "CBRTConnect TSTS Admin"\n'
+            "    legacy_role: Admin\n"
+            "users:\n"
+            "  - email: admin@example.com\n"
+            "    first_name: Ad\n"
+            "    last_name: Min\n"
+            "    role: cbrtconnect_tsts_admin\n"
+            "    auth_type: google\n"
+        )
+
+    def test_slug_defaults_to_tenant_code_lowercase(self):
+        cfg = self._write_yaml(self._yaml())
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        app = Application.objects.get(name="CBRTConnect - TSTS")
+        self.assertEqual(app.slug, "tsts")
+
+    def test_slug_override_in_yaml(self):
+        cfg = self._write_yaml(self._yaml("  slug: custom-override\n"))
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        app = Application.objects.get(name="CBRTConnect - TSTS")
+        self.assertEqual(app.slug, "custom-override")
+
+    def test_slug_override_validation_uppercase_rejected(self):
+        cfg = self._write_yaml(self._yaml("  slug: Custom-Override\n"))
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("slug", msg)
+        self.assertIn("lowercase", msg)
+        # No DB writes
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
+        )
+
+    def test_slug_override_validation_underscore_rejected(self):
+        cfg = self._write_yaml(self._yaml("  slug: custom_override\n"))
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("slug", msg)
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
+        )
+
+    def test_slug_override_validation_trailing_hyphen_rejected(self):
+        cfg = self._write_yaml(self._yaml("  slug: custom-\n"))
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("slug", msg)
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
+        )
+
+    def test_slug_mismatch_error_uses_yaml_slug_when_provided(self):
+        Application.objects.create(
+            name="CBRTConnect - TSTS",
+            slug="old-slug",
+            client_id="app_existing_tsts",
+            client_secret="existing-secret",  # pragma: allowlist secret
+            redirect_uris="https://example.com/oauth/callback/",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.actor,
+        )
+        cfg = self._write_yaml(self._yaml("  slug: new-slug\n"))
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("'new-slug'", msg)
+        self.assertIn("'old-slug'", msg)
+        # Error distinguishes YAML-provided from derived slug
+        self.assertIn("YAML specifies", msg)

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -752,3 +752,57 @@ class ApplicationSlugOverrideTests(ProvisionTenantTestBase):
         self.assertIn("'old-slug'", msg)
         # Error distinguishes YAML-provided from derived slug
         self.assertIn("YAML specifies", msg)
+
+    def test_slug_exactly_50_chars_accepted(self):
+        # Application.slug is SlugField(max_length=50); exactly 50 must pass.
+        slug = "a" + "b" * 48 + "c"  # 50 chars, valid pattern
+        self.assertEqual(len(slug), 50)
+        cfg = self._write_yaml(self._yaml(f"  slug: {slug}\n"))
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        app = Application.objects.get(name="CBRTConnect - TSTS")
+        self.assertEqual(app.slug, slug)
+
+    def test_slug_51_chars_rejected(self):
+        # Schema must reject before Application.save() hits the DB limit.
+        slug = "a" + "b" * 49 + "c"  # 51 chars, valid pattern but too long
+        self.assertEqual(len(slug), 51)
+        cfg = self._write_yaml(self._yaml(f"  slug: {slug}\n"))
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("slug", str(ctx.exception))
+        # No DB writes
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
+        )
+
+    def test_slug_conflict_with_different_app_rejected_at_plan_time(self):
+        # Different app name, same slug — must fail at plan time, not at
+        # Application.save() with an IntegrityError.
+        Application.objects.create(
+            name="CBRTConnect - OTHER",
+            slug="shared-slug",
+            client_id="app_other",
+            client_secret="other-secret",  # pragma: allowlist secret
+            redirect_uris="https://example.com/oauth/callback/",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.actor,
+        )
+        cfg = self._write_yaml(self._yaml("  slug: shared-slug\n"))
+
+        # Real run must reject at plan time.
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("'shared-slug'", msg)
+        self.assertIn("CBRTConnect - OTHER", msg)
+
+        # Dry-run must reject too (plan-time check).
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--dry-run")
+        self.assertIn("'shared-slug'", str(ctx.exception))
+
+        # No Application created under the new name from either attempt.
+        self.assertEqual(
+            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
+        )

--- a/tenants/_template.yaml
+++ b/tenants/_template.yaml
@@ -14,6 +14,9 @@ display_name: "Full Tenant Name"                  # used for the Tenant referenc
 
 application:
   name: "CBRTConnect - XXX"                       # unique across all SSO apps
+  # slug: xxx                                     # Optional. Defaults to tenant_code.lower().
+                                                  # Override when you need a specific slug
+                                                  # (lowercase alphanumeric + hyphens, 2-64 chars).
   redirect_uris:
     - https://cbrtconnect.com/oauth/callback/
     - https://dev.cbrtconnect.com/oauth/callback/

--- a/tenants/_template.yaml
+++ b/tenants/_template.yaml
@@ -16,7 +16,7 @@ application:
   name: "CBRTConnect - XXX"                       # unique across all SSO apps
   # slug: xxx                                     # Optional. Defaults to tenant_code.lower().
                                                   # Override when you need a specific slug
-                                                  # (lowercase alphanumeric + hyphens, 2-64 chars).
+                                                  # (lowercase alphanumeric + hyphens, 2-50 chars).
   redirect_uris:
     - https://cbrtconnect.com/oauth/callback/
     - https://dev.cbrtconnect.com/oauth/callback/


### PR DESCRIPTION
## Summary
- Makes `application.slug` an optional YAML field. Default changes from `f"cbrtconnect-{tenant_code.lower()}"` to bare `tenant_code.lower()`, matching the existing prod convention (primetrade, sacks, yifan, senco, cams, planner, cbrtconnect-dev).
- Operators can override via `application.slug:` when a specific slug is needed (e.g., `cbrtconnect-dev`).
- Schema validates the slug with Django-style rules before any DB interaction: lowercase alphanumeric + hyphens, no underscores, no leading/trailing hyphens, 2-64 chars.

## Why
During first real use (MSP tenant), the hardcoded `cbrtconnect-<code>` derivation was inconsistent with the 7 live production applications, all of which use bare slugs. Rather than retroactively migrate prod, this change aligns the default with existing convention and lets operators override.

## What changed
- `sso/management/commands/_tenant_schema.py` — optional `slug` field on `ApplicationSpec` with regex validator.
- `sso/management/commands/provision_tenant.py` — resolves `cfg.application.slug or cfg.tenant_code.lower()`; removes `_derive_slug`; updates Codex finding 3 mismatch error to differentiate YAML-provided vs derived slug.
- `sso/tests/test_provision_tenant.py` — 6 new tests; 2 mechanical assertion updates for new default.
- `tenants/_template.yaml` — documents optional `slug` field.
- `docs/tenant-onboarding.md` — new subsection on `application.slug`.

## Test plan
- [x] `venv/bin/python3.14 manage.py test sso.tests.test_provision_tenant -v 2` — 30 pass (24 existing + 6 new)
- [x] Dry-run with `slug: msp` shows `Application 'CBRTConnect - MSP Test' slug='msp'`
- [x] Dry-run without `slug` on `tenant_code: MSP` shows `slug='msp'` (derived)
- [x] Pre-commit (black, isort, flake8, bandit, django-upgrade, detect-secrets) all pass
- [ ] Codex review
- [ ] Post-merge: recreate `tenants/msp.yaml` on Render shell with `slug: msp`, dry-run, real run

## Out of scope
- Retroactive slug migration for existing tenants (none needed; this is forward-looking).
- Recording slug in `tenant_provisioning.jsonl` audit log (existing behavior preserved).
- Per-tenant slug rename tooling (use `/cbrt-ops/` if ever needed).

## Rollback
Revert the PR on main; Render auto-deploys. Existing records with bare slugs remain valid — nothing downstream depends on the `cbrtconnect-` prefix specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)