### PR TITLE
feat(provision_tenant)!: bind to existing OAuth Application (breaking)

### DIFF
--- a/docs/tenant-onboarding.md
+++ b/docs/tenant-onboarding.md
@@ -3,18 +3,40 @@
 Operational guide for provisioning a new tenant on `sso.barge2rail.com` using
 the `provision_tenant` management command.
 
-This replaces the ~20-click flow through `/cbrt-ops/` (Django admin) with a
-single YAML-driven command. Review the YAML, dry-run, run for real, capture the
-`client_secret`. Done.
+## What this command does — and doesn't
+
+**Does:** creates tenant-scoped Roles on an **existing** OAuth Application,
+creates Users, binds users to those Roles via `UserAppRole` rows scoped by
+`tenant_code`. Idempotent and transactional.
+
+**Doesn't:** create OAuth Applications. Register a new client app via
+`/cbrt-ops/` (Django admin) first — that flow requires decisions about
+redirect URIs, client type, and allowed scopes that belong in the UI.
+
+Concretely: for a new MSP tenant on CBRTConnect, you do **not** create
+"CBRTConnect - MSP" as a new Application. You bind MSP-scoped roles to the
+existing `sacks` Application (CBRTConnect's OAuth app) using
+`application_slug: sacks` in the YAML.
+
+Why: CBRTConnect authenticates against one OAuth Application (slug `sacks`).
+When a user logs in, the JWT only surfaces roles bound to that Application.
+A role bound to a separate `msp` Application is invisible to CBRTConnect
+and login will 403.
 
 ## Prerequisites
 
-1. **You must have an SSO user** at `sso.barge2rail.com`. The command records
-   you as the `--actor` on the Application and every UserAppRole. If no user
-   with your email exists, the command fails with a message telling you to
-   create one via `/cbrt-ops/` first.
-2. **Repo checkout + activated venv**: `cd ~/Projects/barge2rail-auth && source venv/bin/activate`.
-3. **Database access** for the environment you're provisioning against
+1. **The target OAuth Application already exists** in SSO. Check with:
+   ```bash
+   python manage.py shell -c "from sso.models import Application; print(list(Application.objects.values_list('slug', 'name')))"
+   ```
+   Current production slugs (as of April 2026): `sacks` (CBRTConnect),
+   `primetrade`, `yifan`, `senco`, `cams`, `planner`, `cbrtconnect-dev`.
+2. **You must have an SSO user** at `sso.barge2rail.com`. The command records
+   you as `--actor` on every UserAppRole. If no user with your email exists,
+   the command fails with a message telling you to create one via `/cbrt-ops/`.
+3. **Repo checkout + activated venv**:
+   `cd ~/Projects/barge2rail-auth && source venv/bin/activate`.
+4. **Database access** for the environment you're provisioning against
    (usually dev first, then prod via `git push origin main` + remote shell).
 
 ## Step 1 — Fill in the YAML
@@ -29,12 +51,13 @@ Edit `tenants/msp.yaml`:
 
 - `tenant_code`: short uppercase code (1-10 chars). Must be unique across tenants.
 - `display_name`: full tenant name (used for the `Tenant` reference row).
-- `application.name`: unique across all SSO Applications — include the tenant code
-  (e.g., `"CBRTConnect - MSP"`) to avoid collision.
-- `application.redirect_uris`: OAuth redirect URIs as a list. Trailing slashes must
-  match exactly what the client app sends (Oct 2025 lesson learned).
-- `roles`: the roles this tenant will use. `legacy_role` is what client apps read
-  from the JWT (`application_roles.<slug>.role`); use `Admin` / `Operator` / `Client`
+- `application_slug`: slug of the **existing** OAuth Application to bind to.
+  For CBRTConnect tenants use `sacks`. For PrimeTrade tenants use `primetrade`.
+  Get the list via the shell command above.
+- `roles`: the roles this tenant will use. Convention is
+  `<app_slug>_<tenant_code_lower>_<role>` (e.g. `sacks_msp_admin`).
+  `legacy_role` is what client apps read from the JWT
+  (`application_roles.<slug>.role`); use `Admin` / `Office` / `Client`
   to match CBRTConnect's expectations unless you know otherwise.
 - `users`: one entry per (user, role) binding. A user with multiple roles gets
   multiple entries. **Emails are normalized to lowercase** before any DB
@@ -52,18 +75,6 @@ Edit `tenants/msp.yaml`:
     for `@barge2rail.com` staff.
   - `anonymous` — not supported by `provision_tenant`. Create via `/cbrt-ops/`.
 
-### `application.slug` (optional)
-
-URL-safe identifier for the Application. Used in JWT claims as
-`application_roles.<slug>.tenant_code` / `application_roles.<slug>.role`.
-
-If omitted, defaults to `tenant_code.lower()` (bare slug) — matching the
-existing prod convention for tenants like `primetrade`, `sacks`, `msp`. Override
-when you need a specific slug (e.g., `cbrtconnect-dev` for a dev-only app).
-
-Must be lowercase alphanumeric with hyphens. No underscores, no uppercase, no
-leading/trailing hyphens. 2-50 characters (matches `Application.slug` DB field).
-
 **Do not commit the filled-in YAML.** `tenants/.gitignore` blocks everything except
 `_template.yaml`. Keep the filled YAML locally or in 1Password — it contains user PII.
 
@@ -73,11 +84,18 @@ leading/trailing hyphens. 2-50 characters (matches `Application.slug` DB field).
 python manage.py provision_tenant --config tenants/msp.yaml --dry-run
 ```
 
-Expected output: a plan listing `CREATE` or `SKIP (exists)` for the Tenant,
-Application, each Role, each User, and each UserAppRole binding. Nothing is
-written to the database. If validation fails (missing field, bad email, unknown
-role reference, etc.), you'll get a specific error with a field path — fix the
-YAML and re-run the dry-run.
+Expected output: a plan header naming the resolved Application, then `CREATE`
+or `SKIP (exists)` lines for the Tenant, each Role, each User, and each
+UserAppRole binding. Nothing is written to the database.
+
+Common failures at this stage:
+
+- **`No OAuth Application exists with slug 'X'. Existing slugs: ...`** — the
+  `application_slug` in the YAML doesn't match any registered Application.
+  The error lists the slugs that do exist; pick one, or register a new
+  OAuth Application in `/cbrt-ops/` first if this is truly a new client app.
+- Validation errors (missing field, bad email, unknown role reference) —
+  each is reported with a specific field path. Fix the YAML and re-run.
 
 ## Step 3 — Real run
 
@@ -90,37 +108,27 @@ python manage.py provision_tenant \
 If successful, the command:
 
 1. Writes all records in a single transaction.
-2. Appends one JSON line to `logs/tenant_provisioning.jsonl` (no secrets in it).
-3. Prints a one-time secret banner to stdout:
+2. Appends one JSON line to `logs/tenant_provisioning.jsonl` (no secrets).
+3. If any `auth_type: email` users were created, prints a one-time credentials
+   banner to stdout:
 
    ```
    ================================================================
    COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN
+   Email/password users bound to Application slug='sacks' (temp passwords - distribute privately):
    ================================================================
-   client_id:     app_xxxxxxxxxxxxxxxx
-   client_secret: <64 chars>
+     briana@marianshipping.example.com   <24-char password>
    ================================================================
    ```
-
-**Copy `client_secret` to 1Password immediately.** It is NOT stored anywhere
-else on disk and cannot be recovered later — only rotated (via `/cbrt-ops/`).
-
-If the YAML included any `auth_type: email` users, a second banner follows
-listing each new user's email and their one-time temp password:
-
-```
-================================================================
-COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN
-Email/password users (temp passwords - distribute privately):
-================================================================
-  briana@marianshipping.example.com   <24-char password>
-================================================================
-```
 
 These temp passwords are stored hashed (Django `set_password()`), never written
 to `logs/tenant_provisioning.jsonl`, and cannot be recovered — only reset via
 the password-reset flow. **Distribute via 1Password share or another
 end-to-end-encrypted channel; never Slack/email plaintext.**
+
+Note: because this command doesn't create OAuth Applications, there is no
+`client_secret` banner. If you need the existing app's secret, fetch it from
+`/cbrt-ops/` or Coolify env vars.
 
 ## What to tell email/password users after provisioning
 
@@ -134,32 +142,20 @@ Send each email user:
    If you forget it later, use `https://sso.barge2rail.com/forgot-password/`
    to request a reset email."
 
-Temp passwords pass Django's minimum-length validator (4 chars) — the user
-is free to choose any password meeting that same minimum when they change it.
+## Step 4 — Clean up
 
-## Step 4 — Store and clean up
-
-- **`client_secret`** → 1Password item named `SSO: <tenant_code> client secret`.
-  Also store `client_id` alongside it (not secret, but needed to configure the
-  client app).
-- **Filled YAML** → 1Password attachment on the same item, or a private local
-  directory outside the repo. Do not email, Slack, or Drive it.
-- Share `client_id` + `client_secret` with the client app team via 1Password
-  share link or password manager, never plaintext channels.
+- **Filled YAML** → 1Password attachment, or a private local directory outside
+  the repo. Do not email, Slack, or Drive it.
 
 ## Idempotency
 
 Re-running the same YAML is safe. Existing rows are reported as
 `SKIP (exists)`. The command exits 0 and still appends an audit line
-(`application_skipped: true`, `bindings_created: 0` for a full no-op).
+(`bindings_created: 0` for a full no-op).
 
-If the Application already exists, the secret banner is **not** reprinted —
-the command can't retrieve the plaintext. If you lost it, rotate via
-`/cbrt-ops/` and update the client app.
-
-Same for email/password users: on re-run, existing users are SKIP'd and no
-temp password is printed. If a user lost theirs, they use the
-`/forgot-password/` flow (or an admin resets via `/cbrt-ops/`).
+On re-run, existing email users are SKIP'd and no temp password is printed.
+If a user lost theirs, they use `/forgot-password/` (or an admin resets via
+`/cbrt-ops/`).
 
 ### auth_type mismatch
 
@@ -171,23 +167,26 @@ existing row is wrong; fix via `/cbrt-ops/` if the DB record should change.
 
 ## If something goes wrong
 
+- **`No OAuth Application exists with slug 'X'`**: register the Application
+  in `/cbrt-ops/` first (or fix the slug in the YAML to match an existing one).
 - **Validation error**: YAML field path is in the error message. Fix and re-run
   dry-run.
 - **`Actor '<email>' has no SSO user`**: Create yourself via `/cbrt-ops/` first,
   then re-run.
 - **Mid-transaction failure**: nothing is written (transactional). Fix the
   underlying cause (usually a DB constraint or a migration mismatch) and re-run.
-- **Wrong data got created**: the command prints `application_id` + user emails
-  in the audit line. Open `/cbrt-ops/`, delete the Application (cascades
-  UserAppRoles and Roles), delete the Users and Tenant manually.
+- **Wrong roles got created**: the command prints `application_slug`, role
+  codes, and user emails in the audit line. Open `/cbrt-ops/` and delete the
+  Roles, UserAppRoles, Users, and Tenant manually. Leave the OAuth Application
+  intact — this command never created it.
 
 ## Audit log
 
-`logs/tenant_provisioning.jsonl` — one line per run (dry-runs are NOT appended).
+`logs/tenant_provisioning.jsonl` — one line per real run (dry-runs are NOT appended).
 Each line: `ts`, `actor`, `tenant_code`, `application_id`, `application_name`,
-`application_skipped`, `roles_created`, `users_created`, `bindings_created`,
-`dry_run`. Explicitly contains no `client_id`, no `client_secret`, and no
-email/password user temp passwords.
+`application_slug`, `roles_created`, `users_created`, `bindings_created`,
+`dry_run`. Explicitly contains no `client_secret` and no email/password user
+temp passwords.
 
 Review with:
 
@@ -197,15 +196,66 @@ cat logs/tenant_provisioning.jsonl | jq .
 
 ## Verification checklist (post-run)
 
-1. `/cbrt-ops/` → Applications → new Application exists with correct name, slug, redirect URIs.
-2. `/cbrt-ops/` → Users → each YAML user exists with correct name and the
+1. `/cbrt-ops/` → Applications → the target Application exists (unchanged).
+2. `/cbrt-ops/` → Roles → new Roles are attached to the target Application,
+   with correct `code`, `name`, `legacy_role`.
+3. `/cbrt-ops/` → Users → each YAML user exists with correct name and the
    `auth_type` specified in the YAML (`email` or `google`). Email users have
    a usable password; Google users do not.
-3. `/cbrt-ops/` → UserAppRoles → each (user, role, tenant_code) binding is present and `is_active`.
-4. `/cbrt-ops/` → Tenants → tenant row exists with correct code and display name.
-5. For an email/password user: sign in at `https://sso.barge2rail.com/` with
+4. `/cbrt-ops/` → UserAppRoles → each (user, role, tenant_code) binding is
+   present, `is_active`, and the role belongs to the target Application.
+5. `/cbrt-ops/` → Tenants → tenant row exists with correct code and display name.
+6. For an email/password user: sign in at `https://sso.barge2rail.com/` with
    the temp password; confirm the change-password page is reachable at
    `/change-password/`.
-6. For a Google user: log in to the client app (CBRTConnect) via Google; the
-   JWT should include `application_roles.<slug>.tenant_code == "<TENANT_CODE>"`
-   and `application_roles.<slug>.role == "<legacy_role>"`.
+7. For a Google user: log in to the client app (e.g. CBRTConnect) via Google;
+   the JWT should include `application_roles.<application_slug>.tenant_code == "<TENANT_CODE>"`
+   and `application_roles.<application_slug>.role == "<legacy_role>"`.
+
+## Worked examples
+
+### Onboarding a new tenant on CBRTConnect
+
+```yaml
+tenant_code: MSP
+display_name: "Marian Shipping Partners"
+application_slug: sacks
+roles:
+  - code: sacks_msp_admin
+    name: "Sacks MSP Admin"
+    legacy_role: Admin
+  - code: sacks_msp_office
+    name: "Sacks MSP Office"
+    legacy_role: Office
+  - code: sacks_msp_client
+    name: "Sacks MSP Client"
+    legacy_role: Client
+users:
+  - email: bjackson@marianshipping.com
+    first_name: Briana
+    last_name: Jackson
+    role: sacks_msp_client
+```
+
+### Onboarding a new tenant on PrimeTrade
+
+```yaml
+tenant_code: ACME
+display_name: "Acme Trading Co."
+application_slug: primetrade
+roles:
+  - code: primetrade_acme_admin
+    name: "PrimeTrade Acme Admin"
+    legacy_role: Admin
+users:
+  - email: ops@acme.example.com
+    first_name: Jane
+    last_name: Ops
+    role: primetrade_acme_admin
+    auth_type: email
+```
+
+## Related Docs
+
+- Parent patterns: `../CLAUDE.md`
+- PrimeTrade integration: `../django-primetrade/CLAUDE.md`

--- a/sso/management/commands/_tenant_schema.py
+++ b/sso/management/commands/_tenant_schema.py
@@ -2,6 +2,11 @@
 
 Validation is strict: unknown fields are rejected, role references must resolve,
 and every string that looks like a URL or email is parsed, not just regex-matched.
+
+Schema (v2, bind-to-existing mode):
+- Top-level `application_slug` names an EXISTING OAuth Application to bind to.
+- No `application:` block — this command does not create OAuth Applications.
+  Register apps via /cbrt-ops/ first.
 """
 
 from __future__ import annotations
@@ -13,7 +18,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    HttpUrl,
     field_validator,
     model_validator,
 )
@@ -22,7 +26,7 @@ TENANT_CODE_RE = re.compile(r"^[A-Z0-9]{1,10}$")
 # Django-style slug: lowercase alphanumeric + hyphens, no leading/trailing
 # hyphens, 2-50 chars. Matches the existing prod convention (primetrade,
 # cbrtconnect-dev, etc.) and the Application.slug SlugField(max_length=50)
-# constraint. Fail fast here rather than blowing up at Application.save().
+# constraint.
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$")
 # Pragmatic email regex: good enough to catch typos in hand-written YAML.
 # Deep RFC 5322 conformance would require the email-validator package (not a
@@ -70,39 +74,30 @@ class UserSpec(BaseModel):
         return v
 
 
-class ApplicationSpec(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    name: str = Field(min_length=1, max_length=255)
-    # Optional. When omitted, the command layer defaults to tenant_code.lower()
-    # (bare slug), matching the existing prod convention. When provided,
-    # operators can override for any reason (legacy rename, special casing, etc.)
-    slug: str | None = None
-    redirect_uris: List[HttpUrl] = Field(min_length=1)
-
-    @field_validator("slug")
-    @classmethod
-    def _check_slug(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        if not SLUG_RE.match(v):
-            raise ValueError(
-                "slug must be lowercase alphanumeric with hyphens, "
-                "e.g. 'msp' or 'cbrtconnect-dev' "
-                "(no uppercase, no underscores, no leading/trailing hyphens, "
-                "2-50 chars)"
-            )
-        return v
-
-
 class TenantConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     tenant_code: str
     display_name: str = Field(min_length=1, max_length=100)
-    application: ApplicationSpec
+    # Slug of an EXISTING OAuth Application. Roles created by this run attach
+    # to that Application; UserAppRoles bind users to those Roles scoped by
+    # tenant_code. The Application itself is NOT created here — register it
+    # via /cbrt-ops/ first.
+    application_slug: str = Field(min_length=2, max_length=50)
     roles: List[RoleSpec] = Field(min_length=1)
     users: List[UserSpec] = Field(min_length=1)
+
+    @field_validator("application_slug")
+    @classmethod
+    def _check_application_slug(cls, v: str) -> str:
+        if not SLUG_RE.match(v):
+            raise ValueError(
+                "application_slug must be lowercase alphanumeric with hyphens, "
+                "e.g. 'sacks' or 'cbrtconnect-dev' "
+                "(no uppercase, no underscores, no leading/trailing hyphens, "
+                "2-50 chars)"
+            )
+        return v
 
     @model_validator(mode="after")
     def _check_tenant_code(self) -> "TenantConfig":

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -173,12 +173,31 @@ class Command(BaseCommand):
 
         tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
 
-        existing_role_codes = set(
-            Role.objects.filter(application=app).values_list("code", flat=True)
-        )
+        # Fetch full Role objects (not just codes) so we can detect metadata
+        # mismatches on existing roles. In bind-to-existing mode all tenants
+        # on a given Application share one role namespace — a copy/paste
+        # collision on `code` would otherwise silently bind new users to an
+        # unrelated role, quietly changing their JWT role/permissions.
+        existing_roles_by_code: Dict[str, Role] = {
+            role.code: role for role in Role.objects.filter(application=app)
+        }
         roles_plan: List[Dict[str, Any]] = []
         for r in cfg.roles:
-            roles_plan.append({"spec": r, "exists": r.code in existing_role_codes})
+            existing = existing_roles_by_code.get(r.code)
+            if existing is not None and (
+                existing.name != r.name or existing.legacy_role != r.legacy_role
+            ):
+                raise CommandError(
+                    f"Role code {r.code!r} already exists on Application "
+                    f"slug={app.slug!r} with different metadata:\n"
+                    f"  existing: name={existing.name!r}, legacy_role={existing.legacy_role!r}\n"
+                    f"  YAML:     name={r.name!r}, legacy_role={r.legacy_role!r}\n"
+                    f"This would silently bind tenant users to an unrelated role. "
+                    f"Pick a different role.code, or reconcile the existing row "
+                    f"via /cbrt-ops/ before re-running."
+                )
+            roles_plan.append({"spec": r, "exists": existing is not None})
+        existing_role_codes = set(existing_roles_by_code.keys())
 
         # Finding 2 (inherited): normalize emails and look up case-insensitively.
         # A legacy DB row with mixed-case email matches a lowercase YAML entry;

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -1,4 +1,9 @@
-"""Provision a new tenant: Application + Roles + Users + UserAppRole bindings.
+"""Provision a new tenant: bind Roles, Users, and UserAppRoles to an EXISTING
+OAuth Application.
+
+This command does NOT create OAuth Applications. Register the target app via
+/cbrt-ops/ first, then use this command to populate it with tenant-scoped
+roles and users.
 
 Usage:
     python manage.py provision_tenant --config tenants/msp.yaml --dry-run
@@ -29,7 +34,11 @@ from ._tenant_schema import TenantConfig
 
 
 class Command(BaseCommand):
-    help = "Provision a tenant (Application, Roles, Users, UserAppRoles) from a YAML config."
+    help = (
+        "Bind tenant-scoped Roles, Users, and UserAppRoles to an existing "
+        "OAuth Application (identified by application_slug in the YAML). "
+        "Does not create OAuth Applications — register those via /cbrt-ops/ first."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -75,27 +84,16 @@ class Command(BaseCommand):
         with transaction.atomic():
             result = self._execute(cfg, plan, actor)
 
-        # Banners FIRST — secrets must reach the operator even if audit I/O fails.
-        # DB records are already committed; if we hid the banner behind an I/O
-        # failure, the operator would have a provisioned tenant with no
-        # recoverable client_secret or temp passwords.
-        if result["client_secret_plaintext"]:
-            self._print_secret_banner(
-                result["client_id"], result["client_secret_plaintext"]
-            )
-        elif result["application_skipped"]:
-            self.stdout.write(
-                self.style.WARNING(
-                    "\nApplication already existed; client_secret was only shown on original creation. "
-                    "If lost, rotate via /cbrt-ops/."
-                )
-            )
-
+        # Banner FIRST — temp passwords must reach the operator even if audit
+        # I/O fails. If we hid the banner behind an I/O failure, email users
+        # would have no recoverable credentials.
         if result["email_user_credentials"]:
-            self._print_email_credentials_banner(result["email_user_credentials"])
+            self._print_email_credentials_banner(
+                result["application_slug"], result["email_user_credentials"]
+            )
 
         # Audit LAST. Warn-and-continue on I/O failure; provisioning succeeded
-        # and the secrets have been shown, so don't mislead the operator with a
+        # and any secrets have been shown, so don't mislead the operator with a
         # non-zero exit.
         try:
             self._append_audit(cfg, actor, result, dry_run=False)
@@ -103,13 +101,14 @@ class Command(BaseCommand):
             self.stderr.write(
                 self.style.WARNING(
                     f"Audit log write failed: {e}. "
-                    "Provisioning succeeded; any secrets were displayed above."
+                    "Provisioning succeeded; any temp passwords were displayed above."
                 )
             )
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"\nDone. Tenant '{cfg.tenant_code}' provisioned "
+                f"\nDone. Tenant '{cfg.tenant_code}' bound to Application "
+                f"slug='{result['application_slug']}' "
                 f"(bindings_created={result['bindings_created']})."
             )
         )
@@ -149,57 +148,41 @@ class Command(BaseCommand):
                 "Deduplicate in /cbrt-ops/ before re-running."
             )
 
+    def _resolve_application(self, application_slug: str) -> Application:
+        """Look up the target Application by slug. Missing slug is a fatal
+        operator error: list the known slugs so the fix is obvious."""
+        try:
+            return Application.objects.get(slug=application_slug)
+        except Application.DoesNotExist:
+            existing = sorted(
+                Application.objects.values_list("slug", flat=True).exclude(slug="")
+            )
+            existing_display = ", ".join(existing) if existing else "(none)"
+            raise CommandError(
+                f"No OAuth Application exists with slug '{application_slug}'. "
+                f"Existing slugs: {existing_display}. "
+                f"Register the app in /cbrt-ops/ first, or use an existing one."
+            )
+
     # ---- plan --------------------------------------------------------------
 
     def _build_plan(self, cfg: TenantConfig) -> Dict[str, Any]:
-        slug = cfg.application.slug or cfg.tenant_code.lower()
+        # Resolve the target Application first — this is the most common
+        # failure mode (bad slug) and should surface before any other work.
+        app = self._resolve_application(cfg.application_slug)
 
         tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
-        app = Application.objects.filter(name=cfg.application.name).first()
 
-        # Finding 3: reject mismatched slug BEFORE any writes (and before
-        # dry-run returns a misleading SKIP plan). Catches copy-paste errors
-        # where tenant_code was changed but application.name was not.
-        if app is not None and app.slug != slug:
-            if cfg.application.slug is not None:
-                implication = f"YAML specifies slug '{slug}'"
-            else:
-                implication = (
-                    f"this YAML implies slug '{slug}' (derived from tenant_code)"
-                )
-            raise CommandError(
-                f"Application '{cfg.application.name}' already exists with slug "
-                f"'{app.slug}' but {implication}. "
-                f"Either the tenant_code, application.name, or application.slug "
-                f"is wrong. Refusing to reuse the existing application."
-            )
-
-        # Slug is unique across Applications. If no app matched by name but
-        # some other Application already owns this slug, fail at plan time
-        # with an actionable error instead of an IntegrityError from _execute.
-        if app is None:
-            slug_conflict = Application.objects.filter(slug=slug).first()
-            if slug_conflict is not None:
-                raise CommandError(
-                    f"Slug '{slug}' is already in use by a different Application "
-                    f"'{slug_conflict.name}'. "
-                    f"Choose a different application.slug or resolve via /cbrt-ops/. "
-                    f"Refusing to create a second Application with the same slug."
-                )
-
+        existing_role_codes = set(
+            Role.objects.filter(application=app).values_list("code", flat=True)
+        )
         roles_plan: List[Dict[str, Any]] = []
-        if app:
-            existing_role_codes = set(
-                Role.objects.filter(application=app).values_list("code", flat=True)
-            )
-        else:
-            existing_role_codes = set()
         for r in cfg.roles:
             roles_plan.append({"spec": r, "exists": r.code in existing_role_codes})
 
-        # Finding 2: normalize emails and look up case-insensitively. A legacy
-        # DB row with mixed-case email matches a lowercase YAML entry; if two
-        # rows differ only by case (historical data), fail fast.
+        # Finding 2 (inherited): normalize emails and look up case-insensitively.
+        # A legacy DB row with mixed-case email matches a lowercase YAML entry;
+        # if two rows differ only by case (historical data), fail fast.
         existing_users: Dict[str, User] = {}
         for u in cfg.users:
             email_str = str(u.email).strip().lower()
@@ -236,7 +219,7 @@ class Command(BaseCommand):
             user_obj = existing_users.get(email_str)
             role_exists = u.role in existing_role_codes
             binding_exists = False
-            if app and user_obj and role_exists:
+            if user_obj and role_exists:
                 role_obj = Role.objects.filter(application=app, code=u.role).first()
                 if role_obj:
                     binding_exists = UserAppRole.objects.filter(
@@ -247,9 +230,8 @@ class Command(BaseCommand):
             )
 
         return {
-            "slug": slug,
+            "application": app,
             "tenant_exists": tenant is not None,
-            "app_exists": app is not None,
             "roles": roles_plan,
             "users": users_plan,
             "bindings": bindings_plan,
@@ -259,8 +241,13 @@ class Command(BaseCommand):
         self, cfg: TenantConfig, plan: Dict[str, Any], dry_run: bool
     ) -> None:
         header = "DRY-RUN PLAN" if dry_run else "PROVISION PLAN"
+        app: Application = plan["application"]
         self.stdout.write(
             self.style.MIGRATE_HEADING(f"\n=== {header}: {cfg.tenant_code} ===")
+        )
+        self.stdout.write(
+            f"  Bound to Application: {app.name!r} "
+            f"(slug={app.slug!r}, client_id={app.client_id!r})"
         )
 
         def line(label: str, exists: bool, detail: str = "") -> None:
@@ -272,13 +259,10 @@ class Command(BaseCommand):
         line(
             f"Tenant {cfg.tenant_code!r} ({cfg.display_name!r})", plan["tenant_exists"]
         )
-        line(
-            f"Application {cfg.application.name!r} slug={plan['slug']!r}",
-            plan["app_exists"],
-        )
         for rp in plan["roles"]:
             line(
-                f"Role {rp['spec'].code!r} (legacy={rp['spec'].legacy_role!r})",
+                f"Role {rp['spec'].code!r} (legacy={rp['spec'].legacy_role!r}) "
+                f"on Application slug={app.slug!r}",
                 rp["exists"],
             )
         for up in plan["users"]:
@@ -297,7 +281,7 @@ class Command(BaseCommand):
     def _execute(
         self, cfg: TenantConfig, plan: Dict[str, Any], actor: User
     ) -> Dict[str, Any]:
-        slug = plan["slug"]
+        app: Application = plan["application"]
 
         # Tenant
         Tenant.objects.get_or_create(
@@ -305,28 +289,7 @@ class Command(BaseCommand):
             defaults={"name": cfg.display_name, "is_active": True},
         )
 
-        # Application
-        app = Application.objects.filter(name=cfg.application.name).first()
-        client_secret_plaintext: str | None = None
-        application_skipped = True
-        if app is None:
-            application_skipped = False
-            client_id = self._gen_unique_client_id()
-            client_secret_plaintext = secrets.token_urlsafe(48)
-            redirect_uris = "\n".join(str(u) for u in cfg.application.redirect_uris)
-            app = Application(
-                name=cfg.application.name,
-                slug=slug,
-                client_id=client_id,
-                client_secret=client_secret_plaintext,
-                redirect_uris=redirect_uris,
-                client_type=Application.CLIENT_CONFIDENTIAL,
-                authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-                user=actor,
-            )
-            app.save()
-
-        # Roles
+        # Roles attach to the resolved (pre-existing) Application.
         roles_created: List[str] = []
         role_objs: Dict[str, Role] = {}
         for r in cfg.roles:
@@ -400,20 +363,12 @@ class Command(BaseCommand):
         return {
             "application_id": str(app.id),
             "application_name": app.name,
-            "application_skipped": application_skipped,
-            "client_id": app.client_id if not application_skipped else None,
-            "client_secret_plaintext": client_secret_plaintext,
+            "application_slug": app.slug,
             "roles_created": roles_created,
             "users_created": users_created,
             "bindings_created": bindings_created,
             "email_user_credentials": email_user_credentials,
         }
-
-    def _gen_unique_client_id(self) -> str:
-        while True:
-            candidate = f"app_{secrets.token_hex(8)}"
-            if not Application.objects.filter(client_id=candidate).exists():
-                return candidate
 
     # ---- audit / output ----------------------------------------------------
 
@@ -428,7 +383,7 @@ class Command(BaseCommand):
             "tenant_code": cfg.tenant_code,
             "application_id": result["application_id"],
             "application_name": result["application_name"],
-            "application_skipped": result["application_skipped"],
+            "application_slug": result["application_slug"],
             "roles_created": result["roles_created"],
             "users_created": result["users_created"],
             "bindings_created": result["bindings_created"],
@@ -445,23 +400,15 @@ class Command(BaseCommand):
             except OSError:
                 pass
 
-    def _print_secret_banner(self, client_id: str, client_secret: str) -> None:
-        bar = "=" * 64
-        self.stdout.write("\n" + bar)
-        self.stdout.write("COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN")
-        self.stdout.write(bar)
-        self.stdout.write(f"client_id:     {client_id}")
-        self.stdout.write(f"client_secret: {client_secret}")
-        self.stdout.write(bar)
-
     def _print_email_credentials_banner(
-        self, credentials: List[tuple[str, str]]
+        self, application_slug: str, credentials: List[tuple[str, str]]
     ) -> None:
         bar = "=" * 64
         self.stdout.write("\n" + bar)
         self.stdout.write("COPY THIS NOW - IT WILL NOT BE SHOWN AGAIN")
         self.stdout.write(
-            "Email/password users (temp passwords - distribute privately):"
+            f"Email/password users bound to Application slug='{application_slug}' "
+            f"(temp passwords - distribute privately):"
         )
         self.stdout.write(bar)
         email_width = max(len(e) for e, _ in credentials)

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -1,4 +1,4 @@
-"""Tests for the provision_tenant management command."""
+"""Tests for the provision_tenant management command (bind-to-existing mode)."""
 
 from __future__ import annotations
 
@@ -18,29 +18,26 @@ VALID_YAML = """
 tenant_code: TSTP
 display_name: "Test Provision"
 
-application:
-  name: "CBRTConnect - TSTP"
-  redirect_uris:
-    - https://example.com/oauth/callback/
+application_slug: testapp
 
 roles:
-  - code: cbrtconnect_tstp_admin
-    name: "CBRTConnect TSTP Admin"
+  - code: testapp_tstp_admin
+    name: "TestApp TSTP Admin"
     legacy_role: Admin
-  - code: cbrtconnect_tstp_viewer
-    name: "CBRTConnect TSTP Viewer"
+  - code: testapp_tstp_viewer
+    name: "TestApp TSTP Viewer"
     legacy_role: Client
 
 users:
   - email: alice@tstp.example.com
     first_name: Alice
     last_name: Anderson
-    role: cbrtconnect_tstp_admin
+    role: testapp_tstp_admin
     auth_type: google
   - email: bob@tstp.example.com
     first_name: Bob
     last_name: Brown
-    role: cbrtconnect_tstp_viewer
+    role: testapp_tstp_viewer
     auth_type: google
 """
 
@@ -50,20 +47,22 @@ def _yaml_with_users(users_block: str) -> str:
     return (
         "tenant_code: TSTE\n"
         'display_name: "Test Email"\n'
-        "application:\n"
-        '  name: "CBRTConnect - TSTE"\n'
-        "  redirect_uris:\n"
-        "    - https://example.com/oauth/callback/\n"
+        "application_slug: testapp\n"
         "roles:\n"
-        "  - code: cbrtconnect_tste_client\n"
-        '    name: "CBRTConnect TSTE Client"\n'
+        "  - code: testapp_tste_client\n"
+        '    name: "TestApp TSTE Client"\n'
         "    legacy_role: Client\n"
         "users:\n" + users_block
     )
 
 
 class ProvisionTenantTestBase(TestCase):
-    """Shared setup: temp dir for YAML + audit file, actor user."""
+    """Shared setup: temp dir for YAML + audit file, actor user, target Application.
+
+    Every test gets a pre-existing OAuth Application with slug='testapp' to
+    bind to. Tests that need a different pre-existing app can create one
+    explicitly.
+    """
 
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -79,6 +78,17 @@ class ProvisionTenantTestBase(TestCase):
             last_name="Badante",
             auth_type="google",
             auth_method="google",
+        )
+
+        self.target_app = Application.objects.create(
+            name="TestApp",
+            slug="testapp",
+            client_id="app_testapp_0001",
+            client_secret="testapp-secret-not-real",  # pragma: allowlist secret
+            redirect_uris="https://example.com/oauth/callback/",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.actor,
         )
 
     def _write_yaml(self, content: str, name: str = "tenant.yaml") -> str:
@@ -110,10 +120,9 @@ class DryRunTests(ProvisionTenantTestBase):
         cfg = self._write_yaml(VALID_YAML)
         out = self._run("--config", cfg, "--dry-run")
 
-        self.assertEqual(Application.objects.count(), 0)
+        # Target Application exists from setUp — no new Application created.
+        self.assertEqual(Application.objects.count(), 1)
         self.assertEqual(Role.objects.count(), 0)
-        # Only users that should exist: the actor we created in setUp plus
-        # any seeded by migrations. Neither of the YAML's users should exist.
         self.assertEqual(
             User.objects.filter(
                 email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
@@ -124,6 +133,8 @@ class DryRunTests(ProvisionTenantTestBase):
         self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
         self.assertIn("CREATE", out)
         self.assertIn("DRY-RUN PLAN", out)
+        self.assertIn("Bound to Application:", out)
+        self.assertIn("'testapp'", out)
         self.assertEqual(self._audit_lines(), [])
 
 
@@ -132,14 +143,16 @@ class HappyPathTests(ProvisionTenantTestBase):
         cfg = self._write_yaml(VALID_YAML)
         out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
 
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTP").count(), 1
-        )
-        app = Application.objects.get(name="CBRTConnect - TSTP")
-        self.assertEqual(app.slug, "tstp")
-        self.assertEqual(app.user, self.actor)
+        # No new Application created — the target one is reused.
+        self.assertEqual(Application.objects.count(), 1)
+        app = Application.objects.get(slug="testapp")
+        self.assertEqual(app.id, self.target_app.id)
 
+        # Roles attach to the pre-existing target Application.
         self.assertEqual(Role.objects.filter(application=app).count(), 2)
+        for role in Role.objects.filter(application=app):
+            self.assertEqual(role.application.slug, "testapp")
+
         self.assertEqual(
             User.objects.filter(
                 email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
@@ -153,21 +166,32 @@ class HappyPathTests(ProvisionTenantTestBase):
         self.assertEqual(alice.auth_type, "google")
         self.assertFalse(alice.has_usable_password())
 
-        self.assertIn("COPY THIS NOW", out)
-        self.assertIn(app.client_id, out)
+        # No client_secret banner — we don't create Applications.
+        self.assertNotIn("client_secret", out.lower())
 
         audit = self._audit_lines()
         self.assertEqual(len(audit), 1)
         rec = audit[0]
         self.assertEqual(rec["tenant_code"], "TSTP")
         self.assertEqual(rec["actor"], "clif@barge2rail.com")
+        self.assertEqual(rec["application_slug"], "testapp")
         self.assertEqual(
             sorted(rec["users_created"]),
             ["alice@tstp.example.com", "bob@tstp.example.com"],
         )
         self.assertEqual(rec["bindings_created"], 2)
         self.assertNotIn("client_secret", rec)
-        self.assertNotIn("client_id", rec)
+
+    def test_uar_role_application_matches_resolved(self):
+        """Critical integration check: every UserAppRole.role.application must
+        equal the resolved target Application — otherwise the JWT wouldn't
+        surface the role for logins on that Application."""
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        for uar in UserAppRole.objects.all():
+            self.assertEqual(uar.role.application.slug, "testapp")
+            self.assertEqual(uar.role.application.id, self.target_app.id)
 
 
 class IdempotencyTests(ProvisionTenantTestBase):
@@ -187,12 +211,10 @@ class IdempotencyTests(ProvisionTenantTestBase):
         self.assertEqual(User.objects.count(), user_count)
         self.assertEqual(UserAppRole.objects.count(), binding_count)
         self.assertIn("SKIP (exists)", out)
-        self.assertNotIn("COPY THIS NOW", out)
 
         audit = self._audit_lines()
         self.assertEqual(len(audit), 2)
         self.assertEqual(audit[1]["bindings_created"], 0)
-        self.assertTrue(audit[1]["application_skipped"])
 
 
 class ValidationTests(ProvisionTenantTestBase):
@@ -204,14 +226,12 @@ class ValidationTests(ProvisionTenantTestBase):
         self.assertIn("tenant_code", str(ctx.exception))
 
     def test_invalid_role_reference(self):
-        bad = VALID_YAML.replace(
-            "role: cbrtconnect_tstp_admin", "role: cbrtconnect_tstp_ghost"
-        )
+        bad = VALID_YAML.replace("role: testapp_tstp_admin", "role: testapp_tstp_ghost")
         cfg = self._write_yaml(bad)
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         msg = str(ctx.exception)
-        self.assertIn("cbrtconnect_tstp_ghost", msg)
+        self.assertIn("testapp_tstp_ghost", msg)
 
     def test_invalid_tenant_code(self):
         bad = VALID_YAML.replace("tenant_code: TSTP", "tenant_code: tstp-bad")
@@ -219,6 +239,108 @@ class ValidationTests(ProvisionTenantTestBase):
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         self.assertIn("tenant_code", str(ctx.exception))
+
+
+class ApplicationSlugTests(ProvisionTenantTestBase):
+    """New-schema tests for application_slug: required, must resolve to an
+    existing Application, and Roles attach to that resolved Application."""
+
+    def test_application_slug_required(self):
+        bad = VALID_YAML.replace("application_slug: testapp\n", "")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("application_slug", str(ctx.exception))
+        # Nothing written
+        self.assertEqual(Role.objects.count(), 0)
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+
+    def test_application_slug_not_found(self):
+        bad = VALID_YAML.replace(
+            "application_slug: testapp", "application_slug: nonexistent"
+        )
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("nonexistent", msg)
+        self.assertIn("Existing slugs", msg)
+        # The existing target_app slug appears in the list
+        self.assertIn("testapp", msg)
+        # Nothing written
+        self.assertEqual(Role.objects.count(), 0)
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+
+    def test_application_slug_not_found_on_dry_run(self):
+        """Dry-run must also surface the missing-slug error; operators should
+        never discover bad slugs only at real-run time."""
+        bad = VALID_YAML.replace(
+            "application_slug: testapp", "application_slug: nonexistent"
+        )
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--dry-run")
+        self.assertIn("nonexistent", str(ctx.exception))
+
+    def test_application_slug_resolves_existing(self):
+        """With multiple candidate Applications present, the slug must pick
+        the right one — Roles attach to the chosen App, not the other one."""
+        other_app = Application.objects.create(
+            name="OtherApp",
+            slug="otherapp",
+            client_id="app_other_0002",
+            client_secret="other-secret-not-real",  # pragma: allowlist secret
+            redirect_uris="https://example.com/oauth/callback/",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.actor,
+        )
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        # Roles attach to testapp, not otherapp
+        self.assertEqual(Role.objects.filter(application=self.target_app).count(), 2)
+        self.assertEqual(Role.objects.filter(application=other_app).count(), 0)
+
+    def test_application_slug_invalid_format_rejected(self):
+        """Schema-level rejection: uppercase slug, underscore, trailing hyphen."""
+        for bad_slug in ("TestApp", "test_app", "testapp-"):
+            with self.subTest(slug=bad_slug):
+                bad = VALID_YAML.replace(
+                    "application_slug: testapp", f"application_slug: {bad_slug}"
+                )
+                cfg = self._write_yaml(bad)
+                with self.assertRaises(CommandError) as ctx:
+                    self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+                self.assertIn("application_slug", str(ctx.exception))
+
+
+class NoClientSecretBannerTests(ProvisionTenantTestBase):
+    """This command never creates Applications, so client_secret must never
+    appear in command output."""
+
+    def test_no_client_secret_banner_real_run(self):
+        cfg = self._write_yaml(VALID_YAML)
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertNotIn("client_secret", out.lower())
+        self.assertNotIn("COPY THIS NOW", out.split("Email/password users", 1)[0])
+
+    def test_no_client_secret_banner_dry_run(self):
+        cfg = self._write_yaml(VALID_YAML)
+        out = self._run("--config", cfg, "--dry-run")
+        self.assertNotIn("client_secret", out.lower())
+        self.assertNotIn("COPY THIS NOW", out)
+
+
+class AuditFieldsTests(ProvisionTenantTestBase):
+    def test_audit_records_application_slug(self):
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        audit = self._audit_lines()
+        self.assertEqual(len(audit), 1)
+        self.assertEqual(audit[0]["application_slug"], "testapp")
+        self.assertEqual(audit[0]["application_id"], str(self.target_app.id))
+        self.assertEqual(audit[0]["application_name"], "TestApp")
 
 
 class ActorTests(ProvisionTenantTestBase):
@@ -243,8 +365,9 @@ class ActorTests(ProvisionTenantTestBase):
     def test_actor_case_insensitive(self):
         cfg = self._write_yaml(VALID_YAML)
         self._run("--config", cfg, "--actor", "CLIF@BARGE2RAIL.COM")
-        app = Application.objects.get(name="CBRTConnect - TSTP")
-        self.assertEqual(app.user, self.actor)
+        # UserAppRole was assigned by the case-insensitive-resolved actor
+        uar = UserAppRole.objects.first()
+        self.assertEqual(uar.assigned_by, self.actor)
 
 
 class RollbackTests(ProvisionTenantTestBase):
@@ -263,10 +386,8 @@ class RollbackTests(ProvisionTenantTestBase):
             with self.assertRaises(RuntimeError):
                 self._run("--config", cfg, "--actor", "clif@barge2rail.com")
 
-        # All writes rolled back
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTP").count(), 0
-        )
+        # All writes rolled back: Roles, Users, Bindings, Tenant.
+        # The target Application is unaffected (not created by this run).
         self.assertEqual(Role.objects.count(), 0)
         self.assertEqual(
             User.objects.filter(
@@ -276,6 +397,9 @@ class RollbackTests(ProvisionTenantTestBase):
         )
         self.assertEqual(UserAppRole.objects.count(), 0)
         self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+
+        # Target Application still there
+        self.assertEqual(Application.objects.filter(slug="testapp").count(), 1)
 
         # No audit line written (audit happens after successful commit)
         self.assertEqual(self._audit_lines(), [])
@@ -288,7 +412,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: briana@marianshipping.example.com\n"
         "    first_name: Briana\n"
         "    last_name: Jackson\n"
-        "    role: cbrtconnect_tste_client\n"
+        "    role: testapp_tste_client\n"
         "    auth_type: email\n"
     )
 
@@ -296,7 +420,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: staff@barge2rail.com\n"
         "    first_name: Staff\n"
         "    last_name: Person\n"
-        "    role: cbrtconnect_tste_client\n"
+        "    role: testapp_tste_client\n"
         "    auth_type: google\n"
     )
 
@@ -304,7 +428,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: noauth@example.com\n"
         "    first_name: Default\n"
         "    last_name: Auth\n"
-        "    role: cbrtconnect_tste_client\n"
+        "    role: testapp_tste_client\n"
         # auth_type omitted on purpose
     )
 
@@ -312,12 +436,12 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: briana@marianshipping.example.com\n"
         "    first_name: Briana\n"
         "    last_name: Jackson\n"
-        "    role: cbrtconnect_tste_client\n"
+        "    role: testapp_tste_client\n"
         "    auth_type: email\n"
         "  - email: staff@barge2rail.com\n"
         "    first_name: Staff\n"
         "    last_name: Person\n"
-        "    role: cbrtconnect_tste_client\n"
+        "    role: testapp_tste_client\n"
         "    auth_type: google\n"
     )
 
@@ -325,7 +449,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: anon@example.com\n"
         "    first_name: Anon\n"
         "    last_name: User\n"
-        "    role: cbrtconnect_tste_client\n"
+        "    role: testapp_tste_client\n"
         "    auth_type: anonymous\n"
     )
 
@@ -336,7 +460,6 @@ class EmailAuthTests(ProvisionTenantTestBase):
             stripped = raw.strip()
             if stripped.startswith(email):
                 parts = stripped.split()
-                # Line format: "<email>  <password>"
                 if len(parts) >= 2:
                     return parts[-1]
         raise AssertionError(f"No password line found for {email!r} in stdout")
@@ -355,7 +478,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         temp_password = self._extract_password_for(
             out, "briana@marianshipping.example.com"
         )
-        self.assertGreaterEqual(len(temp_password), 20)  # token_urlsafe(18) ~= 24 chars
+        self.assertGreaterEqual(len(temp_password), 20)
         self.assertTrue(user.check_password(temp_password))
 
     def test_email_user_password_not_in_audit(self):
@@ -368,7 +491,6 @@ class EmailAuthTests(ProvisionTenantTestBase):
         audit_path = self.tmp_path / "tenant_provisioning.jsonl"
         audit_content = audit_path.read_text()
         self.assertNotIn(temp_password, audit_content)
-        # Defense-in-depth: field names that would leak secrets
         self.assertNotIn("temp_password", audit_content)
         self.assertNotIn("password", audit_content)
 
@@ -393,7 +515,6 @@ class EmailAuthTests(ProvisionTenantTestBase):
         self.assertEqual(staff.auth_type, "google")
         self.assertFalse(staff.has_usable_password())
 
-        # Credentials banner lists only the email user
         self.assertIn("Email/password users", out)
         banner_section = out.split("Email/password users", 1)[1]
         self.assertIn("briana@marianshipping.example.com", banner_section)
@@ -416,10 +537,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         self.assertIn("auth_type", msg)
         self.assertIn("anonymous", msg)
         self.assertIn("users.0.auth_type", msg)
-        # Nothing should have been created
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTE").count(), 0
-        )
+        self.assertEqual(Role.objects.count(), 0)
 
     def test_existing_google_user_skipped_with_mismatch_warning(self):
         User.objects.create_user(
@@ -434,10 +552,8 @@ class EmailAuthTests(ProvisionTenantTestBase):
 
         self.assertIn("auth_type mismatch", out)
         user = User.objects.get(email="briana@marianshipping.example.com")
-        # Existing auth_type preserved, not clobbered
         self.assertEqual(user.auth_type, "google")
         self.assertFalse(user.has_usable_password())
-        # No temp password printed for a SKIP'd user
         banner_split = out.split("Email/password users")
         if len(banner_split) > 1:
             self.assertNotIn("briana@marianshipping.example.com", banner_split[1])
@@ -453,12 +569,11 @@ class EmailAuthTests(ProvisionTenantTestBase):
 
         self.assertNotIn("Email/password users", out2)
         user = User.objects.get(email="briana@marianshipping.example.com")
-        # Password not rotated on re-run
         self.assertTrue(user.check_password(original_password))
 
 
 class AuditFailureTests(ProvisionTenantTestBase):
-    """Codex finding 1: banner must print even if audit I/O fails."""
+    """Banner must print even if audit I/O fails."""
 
     def test_audit_failure_does_not_block_banner(self):
         cfg = self._write_yaml(EmailAuthTests.EMAIL_USER_YAML)
@@ -469,7 +584,6 @@ class AuditFailureTests(ProvisionTenantTestBase):
         with mock.patch.object(
             Command, "_append_audit", side_effect=OSError("disk full simulation")
         ):
-            # Must NOT raise — secrets were already shown.
             call_command(
                 "provision_tenant",
                 "--config",
@@ -483,18 +597,12 @@ class AuditFailureTests(ProvisionTenantTestBase):
         stdout_text = out.getvalue()
         stderr_text = err.getvalue()
 
-        # Both banners printed before the audit failure
-        self.assertIn("COPY THIS NOW", stdout_text)
         self.assertIn("briana@marianshipping.example.com", stdout_text)
-
-        # Warning about audit failure landed on stderr
+        self.assertIn("Email/password users", stdout_text)
         self.assertIn("Audit log write failed", stderr_text)
         self.assertIn("disk full simulation", stderr_text)
 
         # DB side effects succeeded
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTE").count(), 1
-        )
         self.assertEqual(
             User.objects.filter(email="briana@marianshipping.example.com").count(), 1
         )
@@ -502,27 +610,24 @@ class AuditFailureTests(ProvisionTenantTestBase):
 
 
 class EmailNormalizationTests(ProvisionTenantTestBase):
-    """Codex finding 2: email lookups must be case-insensitive and stored lowercased."""
+    """Email lookups must be case-insensitive and stored lowercased."""
 
     def test_email_case_normalization_on_create(self):
         yaml_content = _yaml_with_users(
             "  - email: TestUser@Example.COM\n"
             "    first_name: Test\n"
             "    last_name: User\n"
-            "    role: cbrtconnect_tste_client\n"
+            "    role: testapp_tste_client\n"
             "    auth_type: google\n"
         )
         cfg = self._write_yaml(yaml_content)
         out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
 
-        # Stored lowercase
         self.assertEqual(User.objects.filter(email="testuser@example.com").count(), 1)
         self.assertEqual(User.objects.filter(email="TestUser@Example.COM").count(), 0)
 
-        # Plan output shows normalized form
         self.assertIn("testuser@example.com", out)
 
-        # Audit records the normalized email
         audit = self._audit_lines()
         self.assertEqual(audit[0]["users_created"], ["testuser@example.com"])
 
@@ -531,7 +636,7 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
             "  - email: alice@example.com\n"
             "    first_name: Alice\n"
             "    last_name: Case\n"
-            "    role: cbrtconnect_tste_client\n"
+            "    role: testapp_tste_client\n"
             "    auth_type: google\n"
         )
         yaml1 = _yaml_with_users(base_users)
@@ -543,19 +648,13 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
         cfg2 = self._write_yaml(yaml2, name="yaml2.yaml")
         out = self._run("--config", cfg2, "--actor", "clif@barge2rail.com")
 
-        # Second run should SKIP the existing user
         self.assertIn("SKIP (exists)", out)
         self.assertEqual(
             User.objects.filter(email__iexact="alice@example.com").count(), 1
         )
-        # Exactly one binding — no duplicate
         self.assertEqual(UserAppRole.objects.count(), 1)
 
     def test_multiple_users_same_email_different_case(self):
-        # Simulate legacy data: two rows that differ only by case. User.objects.create()
-        # bypasses the UserManager convenience but still runs save() which auto-
-        # generates username from email (case-preserved), so both rows satisfy
-        # the case-sensitive unique constraint at the DB level.
         u1 = User(
             email="bob@example.com",
             first_name="Bob",
@@ -579,7 +678,7 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
             "  - email: bob@example.com\n"
             "    first_name: Bob\n"
             "    last_name: Builder\n"
-            "    role: cbrtconnect_tste_client\n"
+            "    role: testapp_tste_client\n"
             "    auth_type: google\n"
         )
         cfg = self._write_yaml(yaml_content)
@@ -592,217 +691,6 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
         self.assertIn("bob@example.com", msg)
 
         # Nothing else created
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTE").count(), 0
-        )
         self.assertEqual(Role.objects.count(), 0)
         self.assertEqual(UserAppRole.objects.count(), 0)
         self.assertEqual(Tenant.objects.filter(code="TSTE").count(), 0)
-
-
-class ApplicationSlugMismatchTests(ProvisionTenantTestBase):
-    """Codex finding 3: reusing an Application by name must verify slug match."""
-
-    YAML_MSP = """
-tenant_code: MSP
-display_name: "Marian Shipping"
-
-application:
-  name: "CBRTConnect - MSP"
-  redirect_uris:
-    - https://example.com/oauth/callback/
-
-roles:
-  - code: cbrtconnect_msp_admin
-    name: "CBRTConnect MSP Admin"
-    legacy_role: Admin
-
-users:
-  - email: admin@example.com
-    first_name: Ad
-    last_name: Min
-    role: cbrtconnect_msp_admin
-    auth_type: google
-"""
-
-    def _preexisting_mismatched_app(self) -> Application:
-        return Application.objects.create(
-            name="CBRTConnect - MSP",
-            slug="opt",  # wrong tenant's slug (copy-paste error)
-            client_id="app_existing",
-            client_secret="existing-secret",  # pragma: allowlist secret
-            redirect_uris="https://example.com/oauth/callback/",
-            client_type=Application.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-            user=self.actor,
-        )
-
-    def test_application_slug_mismatch_rejected(self):
-        self._preexisting_mismatched_app()
-        cfg = self._write_yaml(self.YAML_MSP)
-
-        # Real run must reject with both slugs named in the error.
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        msg = str(ctx.exception)
-        self.assertIn("'opt'", msg)
-        self.assertIn("'msp'", msg)
-
-        # Dry-run must reject with the same mismatch (plan-time check, not execute-time).
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--dry-run")
-        msg = str(ctx.exception)
-        self.assertIn("'opt'", msg)
-        self.assertIn("'msp'", msg)
-
-        # No DB writes from either attempt.
-        self.assertEqual(Role.objects.count(), 0)
-        self.assertEqual(UserAppRole.objects.count(), 0)
-        self.assertEqual(Tenant.objects.filter(code="MSP").count(), 0)
-        self.assertEqual(User.objects.filter(email="admin@example.com").count(), 0)
-
-
-class ApplicationSlugOverrideTests(ProvisionTenantTestBase):
-    """Optional application.slug field: defaults to tenant_code.lower(),
-    operators may override, schema-level validation rejects invalid values."""
-
-    @staticmethod
-    def _yaml(slug_line: str = "") -> str:
-        """Build a valid YAML with an optional slug line under application:."""
-        return (
-            "tenant_code: TSTS\n"
-            'display_name: "Test Slug"\n'
-            "application:\n"
-            '  name: "CBRTConnect - TSTS"\n'
-            f"{slug_line}"
-            "  redirect_uris:\n"
-            "    - https://example.com/oauth/callback/\n"
-            "roles:\n"
-            "  - code: cbrtconnect_tsts_admin\n"
-            '    name: "CBRTConnect TSTS Admin"\n'
-            "    legacy_role: Admin\n"
-            "users:\n"
-            "  - email: admin@example.com\n"
-            "    first_name: Ad\n"
-            "    last_name: Min\n"
-            "    role: cbrtconnect_tsts_admin\n"
-            "    auth_type: google\n"
-        )
-
-    def test_slug_defaults_to_tenant_code_lowercase(self):
-        cfg = self._write_yaml(self._yaml())
-        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        app = Application.objects.get(name="CBRTConnect - TSTS")
-        self.assertEqual(app.slug, "tsts")
-
-    def test_slug_override_in_yaml(self):
-        cfg = self._write_yaml(self._yaml("  slug: custom-override\n"))
-        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        app = Application.objects.get(name="CBRTConnect - TSTS")
-        self.assertEqual(app.slug, "custom-override")
-
-    def test_slug_override_validation_uppercase_rejected(self):
-        cfg = self._write_yaml(self._yaml("  slug: Custom-Override\n"))
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        msg = str(ctx.exception)
-        self.assertIn("slug", msg)
-        self.assertIn("lowercase", msg)
-        # No DB writes
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
-        )
-
-    def test_slug_override_validation_underscore_rejected(self):
-        cfg = self._write_yaml(self._yaml("  slug: custom_override\n"))
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        msg = str(ctx.exception)
-        self.assertIn("slug", msg)
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
-        )
-
-    def test_slug_override_validation_trailing_hyphen_rejected(self):
-        cfg = self._write_yaml(self._yaml("  slug: custom-\n"))
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        msg = str(ctx.exception)
-        self.assertIn("slug", msg)
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
-        )
-
-    def test_slug_mismatch_error_uses_yaml_slug_when_provided(self):
-        Application.objects.create(
-            name="CBRTConnect - TSTS",
-            slug="old-slug",
-            client_id="app_existing_tsts",
-            client_secret="existing-secret",  # pragma: allowlist secret
-            redirect_uris="https://example.com/oauth/callback/",
-            client_type=Application.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-            user=self.actor,
-        )
-        cfg = self._write_yaml(self._yaml("  slug: new-slug\n"))
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        msg = str(ctx.exception)
-        self.assertIn("'new-slug'", msg)
-        self.assertIn("'old-slug'", msg)
-        # Error distinguishes YAML-provided from derived slug
-        self.assertIn("YAML specifies", msg)
-
-    def test_slug_exactly_50_chars_accepted(self):
-        # Application.slug is SlugField(max_length=50); exactly 50 must pass.
-        slug = "a" + "b" * 48 + "c"  # 50 chars, valid pattern
-        self.assertEqual(len(slug), 50)
-        cfg = self._write_yaml(self._yaml(f"  slug: {slug}\n"))
-        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        app = Application.objects.get(name="CBRTConnect - TSTS")
-        self.assertEqual(app.slug, slug)
-
-    def test_slug_51_chars_rejected(self):
-        # Schema must reject before Application.save() hits the DB limit.
-        slug = "a" + "b" * 49 + "c"  # 51 chars, valid pattern but too long
-        self.assertEqual(len(slug), 51)
-        cfg = self._write_yaml(self._yaml(f"  slug: {slug}\n"))
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        self.assertIn("slug", str(ctx.exception))
-        # No DB writes
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
-        )
-
-    def test_slug_conflict_with_different_app_rejected_at_plan_time(self):
-        # Different app name, same slug — must fail at plan time, not at
-        # Application.save() with an IntegrityError.
-        Application.objects.create(
-            name="CBRTConnect - OTHER",
-            slug="shared-slug",
-            client_id="app_other",
-            client_secret="other-secret",  # pragma: allowlist secret
-            redirect_uris="https://example.com/oauth/callback/",
-            client_type=Application.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-            user=self.actor,
-        )
-        cfg = self._write_yaml(self._yaml("  slug: shared-slug\n"))
-
-        # Real run must reject at plan time.
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        msg = str(ctx.exception)
-        self.assertIn("'shared-slug'", msg)
-        self.assertIn("CBRTConnect - OTHER", msg)
-
-        # Dry-run must reject too (plan-time check).
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--dry-run")
-        self.assertIn("'shared-slug'", str(ctx.exception))
-
-        # No Application created under the new name from either attempt.
-        self.assertEqual(
-            Application.objects.filter(name="CBRTConnect - TSTS").count(), 0
-        )

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -315,6 +315,64 @@ class ApplicationSlugTests(ProvisionTenantTestBase):
                 self.assertIn("application_slug", str(ctx.exception))
 
 
+class RoleMetadataCollisionTests(ProvisionTenantTestBase):
+    """Codex PR #14 P1: a pre-existing Role with the same code but different
+    metadata must fail fast — otherwise a copy-paste mistake would silently
+    bind new users to an unrelated role (e.g. Admin vs Client), changing
+    their JWT legacy_role claim without the operator noticing."""
+
+    def test_role_code_collision_with_different_legacy_role_rejected(self):
+        # Pre-seed a role with the YAML's code but DIFFERENT legacy_role.
+        Role.objects.create(
+            application=self.target_app,
+            code="testapp_tstp_admin",
+            name="Some Unrelated Role",
+            legacy_role="Client",  # YAML says Admin — this must reject
+            is_active=True,
+        )
+        cfg = self._write_yaml(VALID_YAML)
+
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("testapp_tstp_admin", msg)
+        self.assertIn("Client", msg)  # existing legacy_role
+        self.assertIn("Admin", msg)  # YAML legacy_role
+        self.assertIn("Some Unrelated Role", msg)  # existing name
+
+        # Dry-run must also reject
+        with self.assertRaises(CommandError):
+            self._run("--config", cfg, "--dry-run")
+
+        # Nothing else created — no tenant, no users, no bindings.
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+        self.assertEqual(User.objects.filter(email="alice@tstp.example.com").count(), 0)
+        self.assertEqual(UserAppRole.objects.count(), 0)
+
+    def test_role_code_collision_with_different_name_rejected(self):
+        Role.objects.create(
+            application=self.target_app,
+            code="testapp_tstp_admin",
+            name="Different Name",  # YAML says "TestApp TSTP Admin"
+            legacy_role="Admin",
+            is_active=True,
+        )
+        cfg = self._write_yaml(VALID_YAML)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("testapp_tstp_admin", str(ctx.exception))
+
+    def test_idempotent_rerun_still_works_when_metadata_matches(self):
+        """Regression guard: an exact-match pre-existing role must NOT trip
+        the collision check. Idempotent re-runs depend on this."""
+        cfg = self._write_yaml(VALID_YAML)
+        # First run creates the roles
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        # Second run — same YAML, roles already exist with matching metadata
+        out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("SKIP (exists)", out)
+
+
 class NoClientSecretBannerTests(ProvisionTenantTestBase):
     """This command never creates Applications, so client_secret must never
     appear in command output."""

--- a/tenants/_template.yaml
+++ b/tenants/_template.yaml
@@ -1,4 +1,8 @@
-# Tenant provisioning template.
+# Tenant provisioning template (bind-to-existing-application mode).
+#
+# This command binds tenant-scoped Roles and UserAppRoles to an EXISTING
+# OAuth Application. It does NOT create the OAuth Application itself —
+# register it via /cbrt-ops/ first.
 #
 # Copy this file to tenants/<tenant_code>.yaml (e.g. tenants/msp.yaml), fill in
 # real values, then run:
@@ -12,27 +16,25 @@
 tenant_code: XXX                                  # 1-10 chars, uppercase alphanumeric (MSP, OPT, HLR...)
 display_name: "Full Tenant Name"                  # used for the Tenant reference row
 
-application:
-  name: "CBRTConnect - XXX"                       # unique across all SSO apps
-  # slug: xxx                                     # Optional. Defaults to tenant_code.lower().
-                                                  # Override when you need a specific slug
-                                                  # (lowercase alphanumeric + hyphens, 2-50 chars).
-  redirect_uris:
-    - https://cbrtconnect.com/oauth/callback/
-    - https://dev.cbrtconnect.com/oauth/callback/
+# Slug of the EXISTING OAuth Application the tenant belongs to.
+# Examples:
+#   - CBRTConnect tenants → application_slug: sacks
+#   - PrimeTrade tenants  → application_slug: primetrade
+# Register new client apps via /cbrt-ops/ before adding tenants to them.
+application_slug: sacks
 
-# Roles created on the new Application. legacy_role is what client apps read
-# from the JWT (application_roles.<slug>.role). The code is machine-readable
-# and must be unique within this application.
+# Roles created on the target Application. Convention: <app_slug>_<tenant_code_lower>_<role>.
+# legacy_role is what client apps read from the JWT (application_roles.<slug>.role).
+# The code is machine-readable and must be unique within the target Application.
 roles:
-  - code: cbrtconnect_xxx_admin
-    name: "CBRTConnect XXX Admin"
+  - code: sacks_xxx_admin
+    name: "Sacks XXX Admin"
     legacy_role: Admin
-  - code: cbrtconnect_xxx_operator
-    name: "CBRTConnect XXX Operator"
-    legacy_role: Operator
-  - code: cbrtconnect_xxx_viewer
-    name: "CBRTConnect XXX Viewer"
+  - code: sacks_xxx_office
+    name: "Sacks XXX Office"
+    legacy_role: Office
+  - code: sacks_xxx_client
+    name: "Sacks XXX Client"
     legacy_role: Client
 
 # Users bound to roles under this tenant. One role per user per run;
@@ -50,12 +52,31 @@ users:
   - email: contact@example.com
     first_name: First
     last_name: Last
-    role: cbrtconnect_xxx_admin
+    role: sacks_xxx_admin
     auth_type: email
 
   # Example Google OAuth user (staff on barge2rail.com):
   # - email: staff@barge2rail.com
   #   first_name: Staff
   #   last_name: Member
-  #   role: cbrtconnect_xxx_admin
+  #   role: sacks_xxx_admin
   #   auth_type: google
+
+# ---------------------------------------------------------------------------
+# Alternate example: onboarding a tenant to PrimeTrade instead of CBRTConnect.
+# Copy-paste and adapt.
+# ---------------------------------------------------------------------------
+#
+# tenant_code: YYY
+# display_name: "Full Tenant Name"
+# application_slug: primetrade
+# roles:
+#   - code: primetrade_yyy_admin
+#     name: "PrimeTrade YYY Admin"
+#     legacy_role: Admin
+# users:
+#   - email: contact@example.com
+#     first_name: First
+#     last_name: Last
+#     role: primetrade_yyy_admin
+#     auth_type: email


### PR DESCRIPTION
## Summary
- **Breaking schema change.** The YAML `application:` block is gone; replaced by a top-level `application_slug:` naming an **existing** OAuth Application.
- Command no longer creates OAuth Applications. Register via `/cbrt-ops/` first, then use this command to populate with tenants.
- Roles now attach to the resolved target Application. UserAppRoles bind users to those Roles, scoped by `tenant_code`.

## Why
PR #13 shipped a tool that created a new OAuth Application per tenant (e.g. `CBRTConnect - MSP`, slug `msp`). But every client app (CBRTConnect, PrimeTrade, etc.) authenticates against **one** Application each. The JWT claim builder (`oauth_validators.py:210`, `oidc_claims.py:68`) keys `application_roles` by `role.application.slug`, so a role on the orphan `msp` Application is invisible to CBRTConnect (slug `sacks`). Login 403s. Yesterday's first real use (MSP tenant onboarding) hit exactly this.

This PR fixes the tool's contract. Existing good records (MTLO/TRX/YAS/URC/HLR on `sacks`) are untouched — by design.

## Contract
- `application_slug` is required, validated by the slug regex.
- Plan resolves `Application.objects.get(slug=...)` at the top. Missing slug → `CommandError` listing all known slugs (dry-run catches this too).
- Roles attach via `Role.application = app` (matches the `setup_rbac` pattern).
- No `client_secret` banner — we don't own the secret. Temp-password banner still prints for email users, now labeled with the bound slug.
- Audit JSONL gains `application_slug` alongside existing `application_id`/`application_name`.

## Test plan
- [x] `venv/bin/python3.14 manage.py test sso.tests.test_provision_tenant` — 32 pass
- [x] Dry-run with a good slug → shows `Bound to Application: ... (slug='...')` and CREATE lines
- [x] Dry-run with nonexistent slug → errors cleanly, lists existing slugs, zero DB writes
- [x] Full SSO test suite has no new regressions (same 27 pre-existing failures as `main`)
- [x] Pre-commit: black, isort, flake8, bandit, django-upgrade, detect-secrets all pass
- [ ] Codex review
- [ ] Post-merge: Clif deletes orphan MSP records via `/cbrt-ops/`, rewrites `tenants/msp.yaml` with `application_slug: sacks`, dry-run + real run on Render shell, verify Briana can log into CBRTConnect

## Files changed
- `sso/management/commands/_tenant_schema.py` — rewritten: removed `ApplicationSpec`, added top-level `application_slug` with validator.
- `sso/management/commands/provision_tenant.py` — rewritten: removed Application creation, added `_resolve_application`, removed `client_secret` banner, kept everything else (idempotency, audit, rollback, email-user temp passwords, case-insensitive email, auth-type-mismatch warn).
- `sso/tests/test_provision_tenant.py` — rewritten: 32 tests covering the new schema. Preserves the concepts from PR #12/#13 (dry-run, idempotency, rollback, validation, actor, email-auth, audit-failure, email-normalization) and adds slug-required, slug-not-found (real+dry), slug-resolves-existing, slug-invalid-format, UAR-role-application-matches-resolved, no-client-secret-banner, audit-records-slug.
- `tenants/_template.yaml` — rewritten with CBRTConnect (`sacks`) and PrimeTrade (`primetrade`) worked examples.
- `docs/tenant-onboarding.md` — major update. Explicit statement about what this does NOT do, both worked examples, documents the missing-slug error and recovery.

## Out of scope
- Operator cleanup of orphan MSP records on prod — Clif will handle via `/cbrt-ops/` after merge.
- Legacy `ApplicationRole` table — separate PR.
- Touching MTLO/TRX/YAS/URC/HLR on `sacks` — they're correct; this PR doesn't affect them.

## Rollback
Revert the PR. No orphan records created by this code path — we never create Applications anymore. Pre-existing records untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)