### PR TITLE
feat(provision_tenant)!: bind users to existing roles (remove role creation)

### DIFF
--- a/docs/tenant-onboarding.md
+++ b/docs/tenant-onboarding.md
@@ -3,25 +3,43 @@
 Operational guide for provisioning a new tenant on `sso.barge2rail.com` using
 the `provision_tenant` management command.
 
+## v3 BREAKING CHANGE (April 2026)
+
+The YAML schema no longer accepts a top-level `roles:` block. Roles must
+already exist on the target Application before provisioning. Reference them
+via each user's `role_code` field. Old v2 YAMLs containing `roles:` are
+rejected with a v3-specific error message — rewrite them per the worked
+examples below.
+
+Per-user `role:` was renamed to `role_code:` to make the bind-to-existing
+semantics explicit at the call site.
+
+If you need a Role that doesn't exist yet on the target Application, create
+it via `/cbrt-ops/` admin or the `setup_rbac` management command first.
+`provision_tenant` is intentionally narrow: identity bindings only, no RBAC
+schema mutations.
+
 ## What this command does — and doesn't
 
-**Does:** creates tenant-scoped Roles on an **existing** OAuth Application,
-creates Users, binds users to those Roles via `UserAppRole` rows scoped by
-`tenant_code`. Idempotent and transactional.
+**Does:** creates the Tenant reference row, creates Users, and binds those
+users to **existing** Roles via `UserAppRole` rows scoped by `tenant_code`.
+Idempotent and transactional.
 
-**Doesn't:** create OAuth Applications. Register a new client app via
-`/cbrt-ops/` (Django admin) first — that flow requires decisions about
-redirect URIs, client type, and allowed scopes that belong in the UI.
+**Doesn't:** create OAuth Applications, Roles, Features, or
+RoleFeaturePermissions. Register a new client app via `/cbrt-ops/`
+(Django admin) first. Create new Roles via admin or the `setup_rbac`
+management command.
 
-Concretely: for a new MSP tenant on CBRTConnect, you do **not** create
-"CBRTConnect - MSP" as a new Application. You bind MSP-scoped roles to the
-existing `sacks` Application (CBRTConnect's OAuth app) using
-`application_slug: sacks` in the YAML.
+Concretely: for a new MSP tenant on CBRTConnect, you do **not** create a new
+"CBRTConnect - MSP" Application or new MSP-specific Roles. CBRTConnect uses
+shared roles (`sacks_client`, `sacks_office`, `sacks_admin`) on the existing
+`sacks` Application. Onboarding MSP means adding `UserAppRole` rows that bind
+MSP users to those existing roles, with `tenant_code: MSP`.
 
-Why: CBRTConnect authenticates against one OAuth Application (slug `sacks`).
-When a user logs in, the JWT only surfaces roles bound to that Application.
-A role bound to a separate `msp` Application is invisible to CBRTConnect
-and login will 403.
+Why the architecture works this way: CBRTConnect (and every other client app)
+authenticates against one OAuth Application. The JWT only surfaces roles
+bound to that Application. Per-tenant role copies would have zero
+RoleFeaturePermissions and the user would log in and see nothing.
 
 ## Prerequisites
 
@@ -31,12 +49,16 @@ and login will 403.
    ```
    Current production slugs (as of April 2026): `sacks` (CBRTConnect),
    `primetrade`, `yifan`, `senco`, `cams`, `planner`, `cbrtconnect-dev`.
-2. **You must have an SSO user** at `sso.barge2rail.com`. The command records
+2. **The Roles you'll reference already exist** on that Application. Check with:
+   ```bash
+   python manage.py shell -c "from sso.models import Role; print(sorted(Role.objects.filter(application__slug='sacks').values_list('code', flat=True)))"
+   ```
+3. **You must have an SSO user** at `sso.barge2rail.com`. The command records
    you as `--actor` on every UserAppRole. If no user with your email exists,
    the command fails with a message telling you to create one via `/cbrt-ops/`.
-3. **Repo checkout + activated venv**:
+4. **Repo checkout + activated venv**:
    `cd ~/Projects/barge2rail-auth && source venv/bin/activate`.
-4. **Database access** for the environment you're provisioning against
+5. **Database access** for the environment you're provisioning against
    (usually dev first, then prod via `git push origin main` + remote shell).
 
 ## Step 1 — Fill in the YAML
@@ -53,27 +75,27 @@ Edit `tenants/msp.yaml`:
 - `display_name`: full tenant name (used for the `Tenant` reference row).
 - `application_slug`: slug of the **existing** OAuth Application to bind to.
   For CBRTConnect tenants use `sacks`. For PrimeTrade tenants use `primetrade`.
-  Get the list via the shell command above.
-- `roles`: the roles this tenant will use. Convention is
-  `<app_slug>_<tenant_code_lower>_<role>` (e.g. `sacks_msp_admin`).
-  `legacy_role` is what client apps read from the JWT
-  (`application_roles.<slug>.role`); use `Admin` / `Office` / `Client`
-  to match CBRTConnect's expectations unless you know otherwise.
 - `users`: one entry per (user, role) binding. A user with multiple roles gets
   multiple entries. **Emails are normalized to lowercase** before any DB
   interaction — `Bjackson@domain.com` and `bjackson@domain.com` are treated as
   the same user, and the row is stored as `bjackson@domain.com`. If the DB
   already contains two rows that differ only by case (legacy data), the
   command refuses to run and tells you to deduplicate in `/cbrt-ops/` first.
-  Each user has an `auth_type`:
-  - `email` (default) — user will have an email + temp password. Use for tenant
-    clients who are **not** on Google Workspace (e.g. `@marianshipping.com`).
-    The command generates a 24-char cryptographic password per user and prints
-    it once in the banner at end of run. Distribute privately; the user then
-    changes it at `https://sso.barge2rail.com/change-password/` on first login.
-  - `google` — user will sign in via Google OAuth. No password is stored. Use
-    for `@barge2rail.com` staff.
-  - `anonymous` — not supported by `provision_tenant`. Create via `/cbrt-ops/`.
+  Each user has:
+  - `role_code` — must match an **existing** `Role.code` on the target
+    Application. Validation lists the existing role codes if yours doesn't
+    match, so the fix is obvious.
+  - `auth_type`:
+    - `email` (default) — user will have an email + temp password. Use for
+      tenant clients who are **not** on Google Workspace
+      (e.g. `@marianshipping.com`). The command generates a 24-char
+      cryptographic password per user and prints it once in the banner at
+      end of run. Distribute privately; the user then changes it at
+      `https://sso.barge2rail.com/change-password/` on first login.
+    - `google` — user will sign in via Google OAuth. No password is stored.
+      Use for `@barge2rail.com` staff.
+    - `anonymous` — not supported by `provision_tenant`. Create via
+      `/cbrt-ops/`.
 
 **Do not commit the filled-in YAML.** `tenants/.gitignore` blocks everything except
 `_template.yaml`. Keep the filled YAML locally or in 1Password — it contains user PII.
@@ -85,8 +107,8 @@ python manage.py provision_tenant --config tenants/msp.yaml --dry-run
 ```
 
 Expected output: a plan header naming the resolved Application, then `CREATE`
-or `SKIP (exists)` lines for the Tenant, each Role, each User, and each
-UserAppRole binding. Nothing is written to the database.
+or `SKIP (exists)` lines for the Tenant, each User, and each UserAppRole
+binding. Nothing is written to the database.
 
 Common failures at this stage:
 
@@ -94,8 +116,17 @@ Common failures at this stage:
   `application_slug` in the YAML doesn't match any registered Application.
   The error lists the slugs that do exist; pick one, or register a new
   OAuth Application in `/cbrt-ops/` first if this is truly a new client app.
-- Validation errors (missing field, bad email, unknown role reference) —
-  each is reported with a specific field path. Fix the YAML and re-run.
+- **`One or more role_code values do not match any Role on Application slug='X': ...`** —
+  one or more users reference a `role_code` that doesn't exist on the target
+  Application. The error lists every offending user and the existing role
+  codes you can choose from, so you can fix all of them before the next
+  attempt instead of one at a time.
+- **`'roles:' is no longer supported in provision_tenant YAML as of v3 ...`** —
+  the YAML still uses the v2 schema. Remove the top-level `roles:` block and
+  reference existing Role codes via each user's `role_code` field. See worked
+  examples below.
+- Validation errors (missing field, bad email, unknown YAML key) — each is
+  reported with a specific field path. Fix the YAML and re-run.
 
 ## Step 3 — Real run
 
@@ -165,28 +196,42 @@ the SKIP line (e.g. `yaml=email, db=google`) and **does not modify** the
 existing user. This is informational — investigate whether the YAML or the
 existing row is wrong; fix via `/cbrt-ops/` if the DB record should change.
 
+### Tenant display_name mismatch
+
+If a Tenant row already exists for the `tenant_code` with a different
+`display_name`, the command prints a warning at the top of the plan and
+**does not overwrite** the existing row. Reconcile via `/cbrt-ops/` if the
+existing display name is wrong.
+
 ## If something goes wrong
 
 - **`No OAuth Application exists with slug 'X'`**: register the Application
   in `/cbrt-ops/` first (or fix the slug in the YAML to match an existing one).
+- **`One or more role_code values do not match any Role`**: create the missing
+  Roles on the target Application via admin or `setup_rbac` first, then
+  re-run. The error lists every missing code and every existing code so you
+  can fix them all in one pass.
+- **`'roles:' is no longer supported ... as of v3`**: rewrite the YAML to the
+  v3 schema (no top-level `roles:`, per-user `role_code:` referencing existing
+  Role codes). See worked examples below.
 - **Validation error**: YAML field path is in the error message. Fix and re-run
   dry-run.
 - **`Actor '<email>' has no SSO user`**: Create yourself via `/cbrt-ops/` first,
   then re-run.
 - **Mid-transaction failure**: nothing is written (transactional). Fix the
   underlying cause (usually a DB constraint or a migration mismatch) and re-run.
-- **Wrong roles got created**: the command prints `application_slug`, role
-  codes, and user emails in the audit line. Open `/cbrt-ops/` and delete the
-  Roles, UserAppRoles, Users, and Tenant manually. Leave the OAuth Application
-  intact — this command never created it.
+- **Wrong bindings got created**: the command prints `application_slug` and
+  user emails in the audit line. Open `/cbrt-ops/` and delete the
+  UserAppRoles, Users, and Tenant manually. Leave the OAuth Application and
+  Roles intact — this command never created them.
 
 ## Audit log
 
 `logs/tenant_provisioning.jsonl` — one line per real run (dry-runs are NOT appended).
 Each line: `ts`, `actor`, `tenant_code`, `application_id`, `application_name`,
-`application_slug`, `roles_created`, `users_created`, `bindings_created`,
-`dry_run`. Explicitly contains no `client_secret` and no email/password user
-temp passwords.
+`application_slug`, `users_created`, `bindings_created`, `dry_run`. Explicitly
+contains no `client_secret`, no email/password user temp passwords, and no
+`roles_created` (the v3 command doesn't create Roles).
 
 Review with:
 
@@ -197,8 +242,8 @@ cat logs/tenant_provisioning.jsonl | jq .
 ## Verification checklist (post-run)
 
 1. `/cbrt-ops/` → Applications → the target Application exists (unchanged).
-2. `/cbrt-ops/` → Roles → new Roles are attached to the target Application,
-   with correct `code`, `name`, `legacy_role`.
+2. `/cbrt-ops/` → Roles → existing Roles on that Application are unchanged
+   (this command doesn't create or modify Roles).
 3. `/cbrt-ops/` → Users → each YAML user exists with correct name and the
    `auth_type` specified in the YAML (`email` or `google`). Email users have
    a usable password; Google users do not.
@@ -208,52 +253,62 @@ cat logs/tenant_provisioning.jsonl | jq .
 6. For an email/password user: sign in at `https://sso.barge2rail.com/` with
    the temp password; confirm the change-password page is reachable at
    `/change-password/`.
-7. For a Google user: log in to the client app (e.g. CBRTConnect) via Google;
-   the JWT should include `application_roles.<application_slug>.tenant_code == "<TENANT_CODE>"`
-   and `application_roles.<application_slug>.role == "<legacy_role>"`.
+7. For a CBRTConnect login: log in to CBRTConnect; the JWT should include
+   `application_roles.<application_slug>.tenant_code == "<TENANT_CODE>"` and
+   `application_roles.<application_slug>.role == "<legacy_role of the bound Role>"`.
+8. For an existing Role with provisioned RoleFeaturePermissions, the user's
+   "Effective Permissions" view in `/cbrt-ops/` should show the same
+   permissions as any other user bound to the same Role on a different tenant.
 
 ## Worked examples
 
-### Onboarding a new tenant on CBRTConnect
+### Onboarding a new tenant on CBRTConnect (v3)
 
 ```yaml
 tenant_code: MSP
 display_name: "Marian Shipping Partners"
 application_slug: sacks
-roles:
-  - code: sacks_msp_admin
-    name: "Sacks MSP Admin"
-    legacy_role: Admin
-  - code: sacks_msp_office
-    name: "Sacks MSP Office"
-    legacy_role: Office
-  - code: sacks_msp_client
-    name: "Sacks MSP Client"
-    legacy_role: Client
 users:
   - email: bjackson@marianshipping.com
     first_name: Briana
     last_name: Jackson
-    role: sacks_msp_client
+    role_code: sacks_client
+    auth_type: email
 ```
 
-### Onboarding a new tenant on PrimeTrade
+This binds Briana to the existing `sacks_client` Role with `tenant_code='MSP'`,
+giving her exactly the same effective permissions as a `sacks_client` user on
+any other CBRTConnect tenant (MTLO, TRX, URC, HLR, ...).
+
+### Onboarding a new tenant on PrimeTrade (v3)
 
 ```yaml
 tenant_code: ACME
 display_name: "Acme Trading Co."
 application_slug: primetrade
-roles:
-  - code: primetrade_acme_admin
-    name: "PrimeTrade Acme Admin"
-    legacy_role: Admin
 users:
   - email: ops@acme.example.com
     first_name: Jane
     last_name: Ops
-    role: primetrade_acme_admin
+    role_code: primetrade_client
     auth_type: email
 ```
+
+Confirm the actual `role_code` values on the `primetrade` Application before
+using this literally; the command will tell you the existing codes if yours
+doesn't match.
+
+## Migration from v2
+
+If you have a v2 YAML in 1Password or local-only file storage:
+
+1. Delete the entire top-level `roles:` block.
+2. For each user entry, rename `role:` → `role_code:`. Set its value to an
+   **existing** Role code on the target Application (use the shell command in
+   "Prerequisites" step 2 to list them).
+3. Dry-run. If `role_code` doesn't match any existing Role, the command will
+   tell you which codes are valid; create any genuinely-needed missing Roles
+   via admin or `setup_rbac` before retrying.
 
 ## Related Docs
 

--- a/sso/management/commands/_tenant_schema.py
+++ b/sso/management/commands/_tenant_schema.py
@@ -1,18 +1,21 @@
 """YAML schema for `provision_tenant`. Not a public API — leading underscore.
 
-Validation is strict: unknown fields are rejected, role references must resolve,
-and every string that looks like a URL or email is parsed, not just regex-matched.
+Schema (v3, bind-to-existing-roles mode):
+- Top-level `application_slug` names an EXISTING OAuth Application.
+- Each user's `role_code` names an EXISTING Role on that Application.
+- This command does not create OAuth Applications, Roles, Features, or
+  RoleFeaturePermissions. Register apps via /cbrt-ops/ first; create Roles
+  via admin or the `setup_rbac` command.
 
-Schema (v2, bind-to-existing mode):
-- Top-level `application_slug` names an EXISTING OAuth Application to bind to.
-- No `application:` block — this command does not create OAuth Applications.
-  Register apps via /cbrt-ops/ first.
+v3 BREAKING CHANGE from v2 (PR #14):
+- Removed top-level `roles:` block (the tool no longer creates Roles).
+- Per-user field renamed `role:` → `role_code:` to make the bind-to-existing
+  semantics explicit at the call site.
 """
 
 from __future__ import annotations
 
 import re
-from typing import List
 
 from pydantic import (
     BaseModel,
@@ -34,12 +37,14 @@ SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$")
 EMAIL_RE = re.compile(r"^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$")
 
 
-class RoleSpec(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    code: str = Field(min_length=1, max_length=50)
-    name: str = Field(min_length=1, max_length=100)
-    legacy_role: str = Field(min_length=1, max_length=50)
+# Surfaced before pydantic validation so operators get a v3-specific message
+# instead of a generic "extra fields not permitted" pydantic error.
+LEGACY_ROLES_KEY_MESSAGE = (
+    "'roles:' is no longer supported in provision_tenant YAML as of v3. "
+    "Roles must exist on the target Application before provisioning. "
+    "Reference them via each user's role_code. If you need a new Role, "
+    "create it via admin or the setup_rbac command first."
+)
 
 
 class UserSpec(BaseModel):
@@ -48,7 +53,10 @@ class UserSpec(BaseModel):
     email: str = Field(min_length=3, max_length=254)
     first_name: str = Field(min_length=1, max_length=150)
     last_name: str = Field(min_length=1, max_length=150)
-    role: str = Field(min_length=1, max_length=50)
+    # Code of an EXISTING Role on the target Application. The command resolves
+    # this against Role.objects.filter(application=app, code=role_code) and
+    # errors out (listing valid codes) if missing.
+    role_code: str = Field(min_length=1, max_length=50)
     # Defaults to 'email' because client users (the common case) are not Google
     # Workspace accounts. Staff using Google SSO must set this explicitly.
     auth_type: str = Field(default="email")
@@ -79,13 +87,11 @@ class TenantConfig(BaseModel):
 
     tenant_code: str
     display_name: str = Field(min_length=1, max_length=100)
-    # Slug of an EXISTING OAuth Application. Roles created by this run attach
-    # to that Application; UserAppRoles bind users to those Roles scoped by
-    # tenant_code. The Application itself is NOT created here — register it
-    # via /cbrt-ops/ first.
+    # Slug of an EXISTING OAuth Application. UserAppRoles bind users to Roles
+    # on that Application, scoped by tenant_code. The Application itself is
+    # NOT created here — register it via /cbrt-ops/ first.
     application_slug: str = Field(min_length=2, max_length=50)
-    roles: List[RoleSpec] = Field(min_length=1)
-    users: List[UserSpec] = Field(min_length=1)
+    users: list[UserSpec] = Field(min_length=1)
 
     @field_validator("application_slug")
     @classmethod
@@ -109,30 +115,9 @@ class TenantConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _check_role_codes_unique(self) -> "TenantConfig":
-        seen: set[str] = set()
-        for i, role in enumerate(self.roles):
-            if role.code in seen:
-                raise ValueError(f"roles.{i}.code: duplicate role code '{role.code}'")
-            seen.add(role.code)
-        return self
-
-    @model_validator(mode="after")
-    def _check_user_role_refs(self) -> "TenantConfig":
-        valid_codes = {r.code for r in self.roles}
-        for i, user in enumerate(self.users):
-            if user.role not in valid_codes:
-                raise ValueError(
-                    f"users.{i}.role: unknown role '{user.role}' "
-                    f"(not in roles[].code: {sorted(valid_codes)})"
-                )
-        return self
-
-    @model_validator(mode="after")
     def _check_user_emails_unique(self) -> "TenantConfig":
         seen: set[str] = set()
         for i, user in enumerate(self.users):
-            # EmailStr comparison is case-sensitive; normalize for the dup check only.
             normalized = str(user.email).lower()
             if normalized in seen:
                 raise ValueError(f"users.{i}.email: duplicate email '{user.email}'")

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -1,9 +1,9 @@
-"""Provision a new tenant: bind Roles, Users, and UserAppRoles to an EXISTING
-OAuth Application.
+"""Provision a new tenant: bind Users and UserAppRoles to EXISTING Roles on
+an EXISTING OAuth Application.
 
-This command does NOT create OAuth Applications. Register the target app via
-/cbrt-ops/ first, then use this command to populate it with tenant-scoped
-roles and users.
+This command does NOT create OAuth Applications, Roles, Features, or
+RoleFeaturePermissions. Register the target app via /cbrt-ops/ first.
+Create Roles via admin or the `setup_rbac` command.
 
 Usage:
     python manage.py provision_tenant --config tenants/msp.yaml --dry-run
@@ -30,14 +30,15 @@ from pydantic import ValidationError
 
 from sso.models import Application, Role, Tenant, User, UserAppRole
 
-from ._tenant_schema import TenantConfig
+from ._tenant_schema import LEGACY_ROLES_KEY_MESSAGE, TenantConfig
 
 
 class Command(BaseCommand):
     help = (
-        "Bind tenant-scoped Roles, Users, and UserAppRoles to an existing "
-        "OAuth Application (identified by application_slug in the YAML). "
-        "Does not create OAuth Applications — register those via /cbrt-ops/ first."
+        "Bind Users and UserAppRoles to EXISTING Roles on an EXISTING OAuth "
+        "Application (identified by application_slug in the YAML). Does not "
+        "create OAuth Applications or Roles — register apps via /cbrt-ops/ "
+        "and create roles via admin or setup_rbac first."
     )
 
     def add_arguments(self, parser):
@@ -126,6 +127,11 @@ class Command(BaseCommand):
             raise CommandError(
                 f"{config_path}: top-level YAML must be a mapping, got {type(raw).__name__}"
             )
+        # Surface the v3-specific message before pydantic, which would
+        # otherwise emit a generic "extra fields not permitted" error and
+        # leave the operator wondering what to do about it.
+        if "roles" in raw:
+            raise CommandError(LEGACY_ROLES_KEY_MESSAGE)
         try:
             return TenantConfig(**raw)
         except ValidationError as e:
@@ -167,37 +173,39 @@ class Command(BaseCommand):
     # ---- plan --------------------------------------------------------------
 
     def _build_plan(self, cfg: TenantConfig) -> Dict[str, Any]:
-        # Resolve the target Application first — this is the most common
-        # failure mode (bad slug) and should surface before any other work.
+        # Resolve the target Application first — most common failure mode.
         app = self._resolve_application(cfg.application_slug)
 
-        tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
-
-        # Fetch full Role objects (not just codes) so we can detect metadata
-        # mismatches on existing roles. In bind-to-existing mode all tenants
-        # on a given Application share one role namespace — a copy/paste
-        # collision on `code` would otherwise silently bind new users to an
-        # unrelated role, quietly changing their JWT role/permissions.
+        # Resolve every user's Role by code on the target Application. Accumulate
+        # all missing-role failures across all users so the operator gets a full
+        # list in one error instead of fixing them one at a time.
         existing_roles_by_code: Dict[str, Role] = {
             role.code: role for role in Role.objects.filter(application=app)
         }
-        roles_plan: List[Dict[str, Any]] = []
-        for r in cfg.roles:
-            existing = existing_roles_by_code.get(r.code)
-            if existing is not None and (
-                existing.name != r.name or existing.legacy_role != r.legacy_role
-            ):
-                raise CommandError(
-                    f"Role code {r.code!r} already exists on Application "
-                    f"slug={app.slug!r} with different metadata:\n"
-                    f"  existing: name={existing.name!r}, legacy_role={existing.legacy_role!r}\n"
-                    f"  YAML:     name={r.name!r}, legacy_role={r.legacy_role!r}\n"
-                    f"This would silently bind tenant users to an unrelated role. "
-                    f"Pick a different role.code, or reconcile the existing row "
-                    f"via /cbrt-ops/ before re-running."
-                )
-            roles_plan.append({"spec": r, "exists": existing is not None})
-        existing_role_codes = set(existing_roles_by_code.keys())
+        missing: List[str] = []
+        for u in cfg.users:
+            if u.role_code not in existing_roles_by_code:
+                email_str = str(u.email).strip().lower()
+                missing.append(f"  user '{email_str}' references role '{u.role_code}'")
+        if missing:
+            existing_codes_display = (
+                ", ".join(sorted(existing_roles_by_code.keys()))
+                if existing_roles_by_code
+                else "(none)"
+            )
+            raise CommandError(
+                f"One or more role_code values do not match any Role on "
+                f"Application slug='{app.slug}':\n"
+                + "\n".join(missing)
+                + f"\nExisting role codes on '{app.slug}': {existing_codes_display}.\n"
+                "Create missing Roles via admin or the setup_rbac command "
+                "before re-running."
+            )
+
+        tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
+        tenant_name_mismatch: str | None = None
+        if tenant is not None and tenant.name != cfg.display_name:
+            tenant_name_mismatch = f"yaml='{cfg.display_name}', db='{tenant.name}'"
 
         # Finding 2 (inherited): normalize emails and look up case-insensitively.
         # A legacy DB row with mixed-case email matches a lowercase YAML entry;
@@ -236,22 +244,21 @@ class Command(BaseCommand):
         for u in cfg.users:
             email_str = str(u.email).strip().lower()
             user_obj = existing_users.get(email_str)
-            role_exists = u.role in existing_role_codes
+            role_obj = existing_roles_by_code[u.role_code]
             binding_exists = False
-            if user_obj and role_exists:
-                role_obj = Role.objects.filter(application=app, code=u.role).first()
-                if role_obj:
-                    binding_exists = UserAppRole.objects.filter(
-                        user=user_obj, role=role_obj, tenant_code=cfg.tenant_code
-                    ).exists()
+            if user_obj is not None:
+                binding_exists = UserAppRole.objects.filter(
+                    user=user_obj, role=role_obj, tenant_code=cfg.tenant_code
+                ).exists()
             bindings_plan.append(
-                {"email": email_str, "role": u.role, "exists": binding_exists}
+                {"email": email_str, "role_code": u.role_code, "exists": binding_exists}
             )
 
         return {
             "application": app,
+            "resolved_roles": existing_roles_by_code,
             "tenant_exists": tenant is not None,
-            "roles": roles_plan,
+            "tenant_name_mismatch": tenant_name_mismatch,
             "users": users_plan,
             "bindings": bindings_plan,
         }
@@ -268,6 +275,13 @@ class Command(BaseCommand):
             f"  Bound to Application: {app.name!r} "
             f"(slug={app.slug!r}, client_id={app.client_id!r})"
         )
+        if plan["tenant_name_mismatch"]:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  Tenant display_name mismatch: {plan['tenant_name_mismatch']} "
+                    "(existing row NOT modified)"
+                )
+            )
 
         def line(label: str, exists: bool, detail: str = "") -> None:
             tag = "SKIP (exists)" if exists else "CREATE"
@@ -278,12 +292,6 @@ class Command(BaseCommand):
         line(
             f"Tenant {cfg.tenant_code!r} ({cfg.display_name!r})", plan["tenant_exists"]
         )
-        for rp in plan["roles"]:
-            line(
-                f"Role {rp['spec'].code!r} (legacy={rp['spec'].legacy_role!r}) "
-                f"on Application slug={app.slug!r}",
-                rp["exists"],
-            )
         for up in plan["users"]:
             detail = f"auth_type={up['spec'].auth_type}"
             if up["auth_type_mismatch"]:
@@ -291,7 +299,8 @@ class Command(BaseCommand):
             line(f"User {up['email']!r}", up["exists"], detail)
         for bp in plan["bindings"]:
             line(
-                f"UserAppRole user={bp['email']!r} role={bp['role']!r} tenant={cfg.tenant_code!r}",
+                f"UserAppRole user={bp['email']!r} role={bp['role_code']!r} "
+                f"tenant={cfg.tenant_code!r}",
                 bp["exists"],
             )
 
@@ -301,32 +310,18 @@ class Command(BaseCommand):
         self, cfg: TenantConfig, plan: Dict[str, Any], actor: User
     ) -> Dict[str, Any]:
         app: Application = plan["application"]
+        resolved_roles: Dict[str, Role] = plan["resolved_roles"]
 
-        # Tenant
+        # Tenant — get_or_create so a pre-existing row with a different
+        # display_name is preserved (the plan-printer warns about mismatches).
         Tenant.objects.get_or_create(
             code=cfg.tenant_code,
             defaults={"name": cfg.display_name, "is_active": True},
         )
 
-        # Roles attach to the resolved (pre-existing) Application.
-        roles_created: List[str] = []
-        role_objs: Dict[str, Role] = {}
-        for r in cfg.roles:
-            role_obj = Role.objects.filter(application=app, code=r.code).first()
-            if role_obj is None:
-                role_obj = Role.objects.create(
-                    application=app,
-                    code=r.code,
-                    name=r.name,
-                    legacy_role=r.legacy_role,
-                    is_active=True,
-                )
-                roles_created.append(r.code)
-            role_objs[r.code] = role_obj
-
-        # Users — emails are normalized to lowercase on creation, and
-        # existence checks are case-insensitive so a legacy mixed-case DB row
-        # still matches a lowercase YAML entry.
+        # Users — emails normalized to lowercase on creation, existence checks
+        # case-insensitive, so a legacy mixed-case DB row matches a lowercase
+        # YAML entry.
         users_created: List[str] = []
         user_objs: Dict[str, User] = {}
         email_user_credentials: List[tuple[str, str]] = []
@@ -360,12 +355,12 @@ class Command(BaseCommand):
                 user_obj = existing
             user_objs[email_str] = user_obj
 
-        # Bindings
+        # Bindings — bind to the EXISTING resolved Role; never create a Role.
         bindings_created = 0
         for u in cfg.users:
             email_str = str(u.email).strip().lower()
             user_obj = user_objs[email_str]
-            role_obj = role_objs[u.role]
+            role_obj = resolved_roles[u.role_code]
             existing_binding = UserAppRole.objects.filter(
                 user=user_obj, role=role_obj, tenant_code=cfg.tenant_code
             ).first()
@@ -383,7 +378,6 @@ class Command(BaseCommand):
             "application_id": str(app.id),
             "application_name": app.name,
             "application_slug": app.slug,
-            "roles_created": roles_created,
             "users_created": users_created,
             "bindings_created": bindings_created,
             "email_user_credentials": email_user_credentials,
@@ -403,7 +397,6 @@ class Command(BaseCommand):
             "application_id": result["application_id"],
             "application_name": result["application_name"],
             "application_slug": result["application_slug"],
-            "roles_created": result["roles_created"],
             "users_created": result["users_created"],
             "bindings_created": result["bindings_created"],
             "dry_run": dry_run,

--- a/sso/management/commands/provision_tenant.py
+++ b/sso/management/commands/provision_tenant.py
@@ -176,31 +176,59 @@ class Command(BaseCommand):
         # Resolve the target Application first — most common failure mode.
         app = self._resolve_application(cfg.application_slug)
 
-        # Resolve every user's Role by code on the target Application. Accumulate
-        # all missing-role failures across all users so the operator gets a full
-        # list in one error instead of fixing them one at a time.
-        existing_roles_by_code: Dict[str, Role] = {
-            role.code: role for role in Role.objects.filter(application=app)
+        # Resolve every user's Role by code on the target Application. Only
+        # ACTIVE Roles count — Role.is_active=False means "do not assign"
+        # (model help_text). Distinguish "not found" from "exists but inactive"
+        # so the operator gets a specific recovery path (create vs reactivate)
+        # instead of a misleading "not found" for a row that's just disabled.
+        # Accumulate every offender so a multi-user YAML produces one error
+        # listing all problems instead of fixing them one at a time.
+        all_roles_on_app = list(Role.objects.filter(application=app))
+        active_roles_by_code: Dict[str, Role] = {
+            r.code: r for r in all_roles_on_app if r.is_active
         }
-        missing: List[str] = []
+        inactive_codes_on_app: set[str] = {
+            r.code for r in all_roles_on_app if not r.is_active
+        }
+        missing_absent: List[str] = []
+        missing_inactive: List[str] = []
         for u in cfg.users:
-            if u.role_code not in existing_roles_by_code:
-                email_str = str(u.email).strip().lower()
-                missing.append(f"  user '{email_str}' references role '{u.role_code}'")
-        if missing:
+            if u.role_code in active_roles_by_code:
+                continue
+            email_str = str(u.email).strip().lower()
+            if u.role_code in inactive_codes_on_app:
+                missing_inactive.append(
+                    f"  user '{email_str}' references role '{u.role_code}' "
+                    "which exists but is INACTIVE"
+                )
+            else:
+                missing_absent.append(
+                    f"  user '{email_str}' references role '{u.role_code}'"
+                )
+        if missing_absent or missing_inactive:
             existing_codes_display = (
-                ", ".join(sorted(existing_roles_by_code.keys()))
-                if existing_roles_by_code
+                ", ".join(sorted(active_roles_by_code.keys()))
+                if active_roles_by_code
                 else "(none)"
             )
-            raise CommandError(
-                f"One or more role_code values do not match any Role on "
-                f"Application slug='{app.slug}':\n"
-                + "\n".join(missing)
-                + f"\nExisting role codes on '{app.slug}': {existing_codes_display}.\n"
-                "Create missing Roles via admin or the setup_rbac command "
-                "before re-running."
+            lines = [
+                f"Cannot resolve one or more role_code values on Application "
+                f"slug='{app.slug}':"
+            ]
+            if missing_absent:
+                lines.append("Not found:")
+                lines.extend(missing_absent)
+            if missing_inactive:
+                lines.append(
+                    "Exists but inactive (reactivate in admin, or use a "
+                    "different role_code):"
+                )
+                lines.extend(missing_inactive)
+            lines.append(
+                f"Existing ACTIVE role codes on '{app.slug}': "
+                f"{existing_codes_display}."
             )
+            raise CommandError("\n".join(lines))
 
         tenant = Tenant.objects.filter(code=cfg.tenant_code).first()
         tenant_name_mismatch: str | None = None
@@ -244,7 +272,7 @@ class Command(BaseCommand):
         for u in cfg.users:
             email_str = str(u.email).strip().lower()
             user_obj = existing_users.get(email_str)
-            role_obj = existing_roles_by_code[u.role_code]
+            role_obj = active_roles_by_code[u.role_code]
             binding_exists = False
             if user_obj is not None:
                 binding_exists = UserAppRole.objects.filter(
@@ -256,7 +284,7 @@ class Command(BaseCommand):
 
         return {
             "application": app,
-            "resolved_roles": existing_roles_by_code,
+            "resolved_roles": active_roles_by_code,
             "tenant_exists": tenant is not None,
             "tenant_name_mismatch": tenant_name_mismatch,
             "users": users_plan,

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -274,7 +274,7 @@ class RoleResolutionTests(ProvisionTenantTestBase):
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--dry-run")
         msg = str(ctx.exception)
-        self.assertIn("Existing role codes", msg)
+        self.assertIn("Existing ACTIVE role codes", msg)
         self.assertIn("testapp_admin", msg)
         self.assertIn("testapp_client", msg)
 
@@ -316,6 +316,78 @@ class RoleResolutionTests(ProvisionTenantTestBase):
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--dry-run")
         self.assertIn("testapp_ghost", str(ctx.exception))
+
+    def test_inactive_role_rejected_with_specific_message(self):
+        """Codex P2 (PR #15): a Role that exists but has is_active=False must
+        be rejected with a message distinct from 'not found' — pointing the
+        operator at reactivating in admin rather than creating a new Role."""
+        Role.objects.create(
+            application=self.target_app,
+            code="testapp_deprecated",
+            name="TestApp Deprecated",
+            legacy_role="Client",
+            is_active=False,
+        )
+        bad = VALID_YAML.replace(
+            "role_code: testapp_admin", "role_code: testapp_deprecated"
+        )
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("testapp_deprecated", msg)
+        self.assertIn("INACTIVE", msg)
+        self.assertIn("reactivate", msg.lower())
+        self.assertIn("alice@tstp.example.com", msg)
+
+    def test_existing_role_codes_hint_lists_active_only(self):
+        """The hint ('Existing ACTIVE role codes on X: ...') must not suggest
+        inactive codes as valid fixes — that would send the operator down a
+        dead end (pointing `role_code` at another disabled Role)."""
+        Role.objects.create(
+            application=self.target_app,
+            code="testapp_deprecated",
+            name="TestApp Deprecated",
+            legacy_role="Client",
+            is_active=False,
+        )
+        bad = VALID_YAML.replace("role_code: testapp_admin", "role_code: testapp_ghost")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--dry-run")
+        msg = str(ctx.exception)
+        self.assertIn("testapp_admin", msg)
+        self.assertIn("testapp_client", msg)
+        # Split the message at the hint line so we only assert against the
+        # hint, not the "missing-role" lines (which legitimately quote the
+        # bad role_code the operator asked for).
+        hint_section = msg.split("Existing ACTIVE role codes", 1)[1]
+        self.assertNotIn("testapp_deprecated", hint_section)
+
+    def test_absent_role_code_still_distinguished_from_inactive(self):
+        """Regression guard for the split error path: a purely-nonexistent
+        role_code must still produce a 'Not found' message (not an 'inactive'
+        one) even when unrelated inactive roles exist on the same Application."""
+        Role.objects.create(
+            application=self.target_app,
+            code="testapp_deprecated",
+            name="TestApp Deprecated",
+            legacy_role="Client",
+            is_active=False,
+        )
+        bad = VALID_YAML.replace("role_code: testapp_admin", "role_code: testapp_ghost")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("Not found:", msg)
+        self.assertIn("testapp_ghost", msg)
+        # The deprecated role wasn't referenced by any user, so the message
+        # must not falsely claim a user referenced it.
+        self.assertNotIn(
+            "references role 'testapp_deprecated' which exists but is INACTIVE",
+            msg,
+        )
 
     def test_role_must_belong_to_target_application_not_another(self):
         """A Role with the right code on a DIFFERENT Application must not

--- a/sso/tests/test_provision_tenant.py
+++ b/sso/tests/test_provision_tenant.py
@@ -1,4 +1,13 @@
-"""Tests for the provision_tenant management command (bind-to-existing mode)."""
+"""Tests for the provision_tenant management command (v3 bind-to-existing-roles).
+
+v3 contract under test:
+- Command does NOT create OAuth Applications (inherited from v2).
+- Command does NOT create Roles (NEW in v3 — was the v2 behavior).
+- Command resolves each user's `role_code` against existing Roles on the
+  target Application; missing role_code errors out with all offending users
+  listed in one message.
+- Top-level `roles:` key from v2 is rejected with a v3-specific message.
+"""
 
 from __future__ import annotations
 
@@ -20,48 +29,41 @@ display_name: "Test Provision"
 
 application_slug: testapp
 
-roles:
-  - code: testapp_tstp_admin
-    name: "TestApp TSTP Admin"
-    legacy_role: Admin
-  - code: testapp_tstp_viewer
-    name: "TestApp TSTP Viewer"
-    legacy_role: Client
-
 users:
   - email: alice@tstp.example.com
     first_name: Alice
     last_name: Anderson
-    role: testapp_tstp_admin
+    role_code: testapp_admin
     auth_type: google
   - email: bob@tstp.example.com
     first_name: Bob
     last_name: Brown
-    role: testapp_tstp_viewer
+    role_code: testapp_client
     auth_type: google
 """
 
 
 def _yaml_with_users(users_block: str) -> str:
-    """Build a YAML with a single role and a custom users block (indented correctly)."""
+    """Build a YAML with a single tenant and a custom users block (indented correctly)."""
     return (
         "tenant_code: TSTE\n"
         'display_name: "Test Email"\n'
         "application_slug: testapp\n"
-        "roles:\n"
-        "  - code: testapp_tste_client\n"
-        '    name: "TestApp TSTE Client"\n'
-        "    legacy_role: Client\n"
         "users:\n" + users_block
     )
 
 
 class ProvisionTenantTestBase(TestCase):
-    """Shared setup: temp dir for YAML + audit file, actor user, target Application.
+    """Shared setup: temp dir for YAML + audit file, actor user, target
+    Application, and two pre-existing Roles on that Application.
 
-    Every test gets a pre-existing OAuth Application with slug='testapp' to
-    bind to. Tests that need a different pre-existing app can create one
-    explicitly.
+    Every test gets:
+      - `self.target_app` — Application(slug='testapp')
+      - `self.role_admin` — Role(application=target_app, code='testapp_admin')
+      - `self.role_client` — Role(application=target_app, code='testapp_client')
+
+    These are the role_codes referenced by VALID_YAML. v3 will not create
+    Roles itself, so they must exist before any happy-path test runs.
     """
 
     def setUp(self) -> None:
@@ -90,6 +92,24 @@ class ProvisionTenantTestBase(TestCase):
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             user=self.actor,
         )
+
+        self.role_admin = Role.objects.create(
+            application=self.target_app,
+            code="testapp_admin",
+            name="TestApp Admin",
+            legacy_role="Admin",
+            is_active=True,
+        )
+        self.role_client = Role.objects.create(
+            application=self.target_app,
+            code="testapp_client",
+            name="TestApp Client",
+            legacy_role="Client",
+            is_active=True,
+        )
+        # Snapshot of pre-existing Role count so tests can assert "no new
+        # Roles created" without hardcoding the number.
+        self._initial_role_count = Role.objects.count()
 
     def _write_yaml(self, content: str, name: str = "tenant.yaml") -> str:
         p = self.tmp_path / name
@@ -120,9 +140,8 @@ class DryRunTests(ProvisionTenantTestBase):
         cfg = self._write_yaml(VALID_YAML)
         out = self._run("--config", cfg, "--dry-run")
 
-        # Target Application exists from setUp — no new Application created.
         self.assertEqual(Application.objects.count(), 1)
-        self.assertEqual(Role.objects.count(), 0)
+        self.assertEqual(Role.objects.count(), self._initial_role_count)
         self.assertEqual(
             User.objects.filter(
                 email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
@@ -139,20 +158,15 @@ class DryRunTests(ProvisionTenantTestBase):
 
 
 class HappyPathTests(ProvisionTenantTestBase):
-    def test_happy_path_creates_everything(self):
+    def test_happy_path_creates_users_and_bindings_no_roles(self):
         cfg = self._write_yaml(VALID_YAML)
         out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
 
-        # No new Application created — the target one is reused.
+        # No new Application, no new Roles.
         self.assertEqual(Application.objects.count(), 1)
-        app = Application.objects.get(slug="testapp")
-        self.assertEqual(app.id, self.target_app.id)
+        self.assertEqual(Role.objects.count(), self._initial_role_count)
 
-        # Roles attach to the pre-existing target Application.
-        self.assertEqual(Role.objects.filter(application=app).count(), 2)
-        for role in Role.objects.filter(application=app):
-            self.assertEqual(role.application.slug, "testapp")
-
+        # Users + bindings + tenant created.
         self.assertEqual(
             User.objects.filter(
                 email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
@@ -169,6 +183,10 @@ class HappyPathTests(ProvisionTenantTestBase):
         # No client_secret banner — we don't create Applications.
         self.assertNotIn("client_secret", out.lower())
 
+    def test_happy_path_audit_record(self):
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
         audit = self._audit_lines()
         self.assertEqual(len(audit), 1)
         rec = audit[0]
@@ -181,6 +199,8 @@ class HappyPathTests(ProvisionTenantTestBase):
         )
         self.assertEqual(rec["bindings_created"], 2)
         self.assertNotIn("client_secret", rec)
+        # v3: no roles_created field — the command doesn't create Roles.
+        self.assertNotIn("roles_created", rec)
 
     def test_uar_role_application_matches_resolved(self):
         """Critical integration check: every UserAppRole.role.application must
@@ -193,9 +213,20 @@ class HappyPathTests(ProvisionTenantTestBase):
             self.assertEqual(uar.role.application.slug, "testapp")
             self.assertEqual(uar.role.application.id, self.target_app.id)
 
+    def test_uar_binds_to_pre_existing_role_objects(self):
+        """The bindings must reference the EXACT pre-existing Role rows, not
+        new ones — confirms 'bind to existing' semantics."""
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
+        alice_uar = UserAppRole.objects.get(user__email="alice@tstp.example.com")
+        bob_uar = UserAppRole.objects.get(user__email="bob@tstp.example.com")
+        self.assertEqual(alice_uar.role_id, self.role_admin.id)
+        self.assertEqual(bob_uar.role_id, self.role_client.id)
+
 
 class IdempotencyTests(ProvisionTenantTestBase):
-    def test_idempotent_rerun(self):
+    def test_idempotent_rerun_no_new_writes(self):
         cfg = self._write_yaml(VALID_YAML)
         self._run("--config", cfg, "--actor", "clif@barge2rail.com")
 
@@ -212,38 +243,160 @@ class IdempotencyTests(ProvisionTenantTestBase):
         self.assertEqual(UserAppRole.objects.count(), binding_count)
         self.assertIn("SKIP (exists)", out)
 
+    def test_idempotent_audit_records_zero_bindings(self):
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+
         audit = self._audit_lines()
         self.assertEqual(len(audit), 2)
         self.assertEqual(audit[1]["bindings_created"], 0)
+        self.assertEqual(audit[1]["users_created"], [])
 
 
-class ValidationTests(ProvisionTenantTestBase):
-    def test_invalid_yaml_missing_field(self):
-        bad = VALID_YAML.replace("tenant_code: TSTP\n", "")
-        cfg = self._write_yaml(bad)
-        with self.assertRaises(CommandError) as ctx:
-            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        self.assertIn("tenant_code", str(ctx.exception))
+class RoleResolutionTests(ProvisionTenantTestBase):
+    """v3-specific: the command must look up each user's role_code against
+    existing Roles on the target Application, accumulate ALL missing-role
+    failures, and write nothing if any are missing."""
 
-    def test_invalid_role_reference(self):
-        bad = VALID_YAML.replace("role: testapp_tstp_admin", "role: testapp_tstp_ghost")
+    def test_unknown_role_code_errors(self):
+        bad = VALID_YAML.replace("role_code: testapp_admin", "role_code: testapp_ghost")
         cfg = self._write_yaml(bad)
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         msg = str(ctx.exception)
-        self.assertIn("testapp_tstp_ghost", msg)
+        self.assertIn("testapp_ghost", msg)
+        self.assertIn("alice@tstp.example.com", msg)
 
-    def test_invalid_tenant_code(self):
-        bad = VALID_YAML.replace("tenant_code: TSTP", "tenant_code: tstp-bad")
+    def test_unknown_role_code_error_lists_existing_codes(self):
+        bad = VALID_YAML.replace("role_code: testapp_admin", "role_code: testapp_ghost")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--dry-run")
+        msg = str(ctx.exception)
+        self.assertIn("Existing role codes", msg)
+        self.assertIn("testapp_admin", msg)
+        self.assertIn("testapp_client", msg)
+
+    def test_multiple_missing_role_codes_all_reported(self):
+        """If two users reference missing Roles, the error must name BOTH
+        users in one message — not stop at the first."""
+        bad = VALID_YAML.replace(
+            "role_code: testapp_admin", "role_code: testapp_ghost1"
+        ).replace("role_code: testapp_client", "role_code: testapp_ghost2")
         cfg = self._write_yaml(bad)
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        self.assertIn("tenant_code", str(ctx.exception))
+        msg = str(ctx.exception)
+        self.assertIn("testapp_ghost1", msg)
+        self.assertIn("testapp_ghost2", msg)
+        self.assertIn("alice@tstp.example.com", msg)
+        self.assertIn("bob@tstp.example.com", msg)
+
+    def test_no_db_writes_on_unknown_role_code(self):
+        bad = VALID_YAML.replace("role_code: testapp_admin", "role_code: testapp_ghost")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError):
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertEqual(Role.objects.count(), self._initial_role_count)
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+        self.assertEqual(
+            User.objects.filter(
+                email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
+            ).count(),
+            0,
+        )
+        self.assertEqual(UserAppRole.objects.count(), 0)
+        self.assertEqual(self._audit_lines(), [])
+
+    def test_unknown_role_code_dry_run_also_errors(self):
+        """Operators must discover bad role_codes at dry-run time, not real-run time."""
+        bad = VALID_YAML.replace("role_code: testapp_admin", "role_code: testapp_ghost")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--dry-run")
+        self.assertIn("testapp_ghost", str(ctx.exception))
+
+    def test_role_must_belong_to_target_application_not_another(self):
+        """A Role with the right code on a DIFFERENT Application must not
+        satisfy a binding on the resolved Application."""
+        other_app = Application.objects.create(
+            name="OtherApp",
+            slug="otherapp",
+            client_id="app_other_0002",
+            client_secret="other-secret-not-real",  # pragma: allowlist secret
+            redirect_uris="https://example.com/oauth/callback/",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.actor,
+        )
+        # Create a Role on otherapp with the code the YAML wants — but the
+        # YAML targets testapp, so this should NOT satisfy.
+        Role.objects.create(
+            application=other_app,
+            code="testapp_only_on_other",
+            name="On Other Only",
+            legacy_role="Admin",
+            is_active=True,
+        )
+        bad = VALID_YAML.replace(
+            "role_code: testapp_admin", "role_code: testapp_only_on_other"
+        )
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("testapp_only_on_other", str(ctx.exception))
+
+
+class LegacyRolesKeyTests(ProvisionTenantTestBase):
+    """v2 YAMLs include a top-level `roles:` block. v3 must reject these with
+    a specific, actionable error message — not a generic pydantic 'extra
+    fields' error."""
+
+    LEGACY_V2_YAML = """
+tenant_code: TSTP
+display_name: "Legacy v2"
+
+application_slug: testapp
+
+roles:
+  - code: testapp_admin
+    name: "TestApp Admin"
+    legacy_role: Admin
+
+users:
+  - email: alice@tstp.example.com
+    first_name: Alice
+    last_name: Anderson
+    role: testapp_admin
+    auth_type: google
+"""
+
+    def test_legacy_roles_key_rejected_with_v3_message(self):
+        cfg = self._write_yaml(self.LEGACY_V2_YAML)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        msg = str(ctx.exception)
+        self.assertIn("'roles:'", msg)
+        self.assertIn("v3", msg)
+        self.assertIn("role_code", msg)
+
+    def test_legacy_roles_key_rejected_dry_run(self):
+        cfg = self._write_yaml(self.LEGACY_V2_YAML)
+        with self.assertRaises(CommandError):
+            self._run("--config", cfg, "--dry-run")
+
+    def test_legacy_roles_key_no_writes(self):
+        cfg = self._write_yaml(self.LEGACY_V2_YAML)
+        with self.assertRaises(CommandError):
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
+        self.assertEqual(User.objects.filter(email="alice@tstp.example.com").count(), 0)
+        self.assertEqual(UserAppRole.objects.count(), 0)
 
 
 class ApplicationSlugTests(ProvisionTenantTestBase):
-    """New-schema tests for application_slug: required, must resolve to an
-    existing Application, and Roles attach to that resolved Application."""
+    """application_slug: required, must resolve to an existing Application."""
 
     def test_application_slug_required(self):
         bad = VALID_YAML.replace("application_slug: testapp\n", "")
@@ -251,8 +404,6 @@ class ApplicationSlugTests(ProvisionTenantTestBase):
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         self.assertIn("application_slug", str(ctx.exception))
-        # Nothing written
-        self.assertEqual(Role.objects.count(), 0)
         self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
 
     def test_application_slug_not_found(self):
@@ -265,15 +416,10 @@ class ApplicationSlugTests(ProvisionTenantTestBase):
         msg = str(ctx.exception)
         self.assertIn("nonexistent", msg)
         self.assertIn("Existing slugs", msg)
-        # The existing target_app slug appears in the list
         self.assertIn("testapp", msg)
-        # Nothing written
-        self.assertEqual(Role.objects.count(), 0)
         self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
 
     def test_application_slug_not_found_on_dry_run(self):
-        """Dry-run must also surface the missing-slug error; operators should
-        never discover bad slugs only at real-run time."""
         bad = VALID_YAML.replace(
             "application_slug: testapp", "application_slug: nonexistent"
         )
@@ -284,7 +430,7 @@ class ApplicationSlugTests(ProvisionTenantTestBase):
 
     def test_application_slug_resolves_existing(self):
         """With multiple candidate Applications present, the slug must pick
-        the right one — Roles attach to the chosen App, not the other one."""
+        the right one — bindings attach to the chosen App's Roles, not the other."""
         other_app = Application.objects.create(
             name="OtherApp",
             slug="otherapp",
@@ -295,15 +441,22 @@ class ApplicationSlugTests(ProvisionTenantTestBase):
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             user=self.actor,
         )
+        # Same role code on the wrong app — must not satisfy bindings for testapp.
+        Role.objects.create(
+            application=other_app,
+            code="testapp_admin",
+            name="Wrong App Admin",
+            legacy_role="Admin",
+            is_active=True,
+        )
         cfg = self._write_yaml(VALID_YAML)
         self._run("--config", cfg, "--actor", "clif@barge2rail.com")
 
-        # Roles attach to testapp, not otherapp
-        self.assertEqual(Role.objects.filter(application=self.target_app).count(), 2)
-        self.assertEqual(Role.objects.filter(application=other_app).count(), 0)
+        for uar in UserAppRole.objects.all():
+            self.assertEqual(uar.role.application_id, self.target_app.id)
+            self.assertNotEqual(uar.role.application_id, other_app.id)
 
     def test_application_slug_invalid_format_rejected(self):
-        """Schema-level rejection: uppercase slug, underscore, trailing hyphen."""
         for bad_slug in ("TestApp", "test_app", "testapp-"):
             with self.subTest(slug=bad_slug):
                 bad = VALID_YAML.replace(
@@ -315,62 +468,81 @@ class ApplicationSlugTests(ProvisionTenantTestBase):
                 self.assertIn("application_slug", str(ctx.exception))
 
 
-class RoleMetadataCollisionTests(ProvisionTenantTestBase):
-    """Codex PR #14 P1: a pre-existing Role with the same code but different
-    metadata must fail fast — otherwise a copy-paste mistake would silently
-    bind new users to an unrelated role (e.g. Admin vs Client), changing
-    their JWT legacy_role claim without the operator noticing."""
+class ValidationTests(ProvisionTenantTestBase):
+    def test_invalid_yaml_missing_tenant_code(self):
+        bad = VALID_YAML.replace("tenant_code: TSTP\n", "")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("tenant_code", str(ctx.exception))
 
-    def test_role_code_collision_with_different_legacy_role_rejected(self):
-        # Pre-seed a role with the YAML's code but DIFFERENT legacy_role.
-        Role.objects.create(
-            application=self.target_app,
-            code="testapp_tstp_admin",
-            name="Some Unrelated Role",
-            legacy_role="Client",  # YAML says Admin — this must reject
-            is_active=True,
+    def test_invalid_tenant_code_format(self):
+        bad = VALID_YAML.replace("tenant_code: TSTP", "tenant_code: tstp-bad")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("tenant_code", str(ctx.exception))
+
+    def test_unknown_top_level_key_rejected(self):
+        bad = VALID_YAML + "\nschema_version: 3\n"
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("schema_version", str(ctx.exception))
+
+    def test_unknown_user_field_rejected(self):
+        bad = VALID_YAML.replace(
+            "    role_code: testapp_admin",
+            "    role_code: testapp_admin\n    surprise: true",
+            1,
         )
-        cfg = self._write_yaml(VALID_YAML)
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("surprise", str(ctx.exception))
 
+    def test_old_role_field_name_rejected(self):
+        """A v2 YAML inside a v3 schema (no top-level roles:, but per-user
+        `role:` instead of `role_code:`) must be rejected."""
+        bad = VALID_YAML.replace("role_code:", "role:")
+        cfg = self._write_yaml(bad)
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         msg = str(ctx.exception)
-        self.assertIn("testapp_tstp_admin", msg)
-        self.assertIn("Client", msg)  # existing legacy_role
-        self.assertIn("Admin", msg)  # YAML legacy_role
-        self.assertIn("Some Unrelated Role", msg)  # existing name
+        # Pydantic flags `role` as extra (forbidden) AND `role_code` as missing.
+        self.assertTrue("role" in msg)
 
-        # Dry-run must also reject
-        with self.assertRaises(CommandError):
-            self._run("--config", cfg, "--dry-run")
-
-        # Nothing else created — no tenant, no users, no bindings.
-        self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
-        self.assertEqual(User.objects.filter(email="alice@tstp.example.com").count(), 0)
-        self.assertEqual(UserAppRole.objects.count(), 0)
-
-    def test_role_code_collision_with_different_name_rejected(self):
-        Role.objects.create(
-            application=self.target_app,
-            code="testapp_tstp_admin",
-            name="Different Name",  # YAML says "TestApp TSTP Admin"
-            legacy_role="Admin",
-            is_active=True,
-        )
-        cfg = self._write_yaml(VALID_YAML)
+    def test_duplicate_emails_rejected(self):
+        bad = VALID_YAML.replace("bob@tstp.example.com", "alice@tstp.example.com")
+        cfg = self._write_yaml(bad)
         with self.assertRaises(CommandError) as ctx:
             self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        self.assertIn("testapp_tstp_admin", str(ctx.exception))
+        self.assertIn("duplicate email", str(ctx.exception))
 
-    def test_idempotent_rerun_still_works_when_metadata_matches(self):
-        """Regression guard: an exact-match pre-existing role must NOT trip
-        the collision check. Idempotent re-runs depend on this."""
+    def test_role_code_field_required(self):
+        bad = VALID_YAML.replace("    role_code: testapp_admin\n", "")
+        cfg = self._write_yaml(bad)
+        with self.assertRaises(CommandError) as ctx:
+            self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        self.assertIn("role_code", str(ctx.exception))
+
+
+class TenantTests(ProvisionTenantTestBase):
+    def test_tenant_get_or_create_when_missing(self):
         cfg = self._write_yaml(VALID_YAML)
-        # First run creates the roles
         self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        # Second run — same YAML, roles already exist with matching metadata
+        tenant = Tenant.objects.get(code="TSTP")
+        self.assertEqual(tenant.name, "Test Provision")
+        self.assertTrue(tenant.is_active)
+
+    def test_existing_tenant_with_different_display_name_not_overwritten(self):
+        Tenant.objects.create(code="TSTP", name="Pre-existing Name", is_active=True)
+        cfg = self._write_yaml(VALID_YAML)
         out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
-        self.assertIn("SKIP (exists)", out)
+
+        tenant = Tenant.objects.get(code="TSTP")
+        self.assertEqual(tenant.name, "Pre-existing Name")
+        self.assertIn("display_name mismatch", out)
 
 
 class NoClientSecretBannerTests(ProvisionTenantTestBase):
@@ -381,7 +553,7 @@ class NoClientSecretBannerTests(ProvisionTenantTestBase):
         cfg = self._write_yaml(VALID_YAML)
         out = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         self.assertNotIn("client_secret", out.lower())
-        self.assertNotIn("COPY THIS NOW", out.split("Email/password users", 1)[0])
+        self.assertNotIn("COPY THIS NOW", out)  # no email users in VALID_YAML
 
     def test_no_client_secret_banner_dry_run(self):
         cfg = self._write_yaml(VALID_YAML)
@@ -399,6 +571,13 @@ class AuditFieldsTests(ProvisionTenantTestBase):
         self.assertEqual(audit[0]["application_slug"], "testapp")
         self.assertEqual(audit[0]["application_id"], str(self.target_app.id))
         self.assertEqual(audit[0]["application_name"], "TestApp")
+
+    def test_audit_has_no_roles_created_field(self):
+        """v3 doesn't create Roles, so the audit record must not pretend it might."""
+        cfg = self._write_yaml(VALID_YAML)
+        self._run("--config", cfg, "--actor", "clif@barge2rail.com")
+        audit = self._audit_lines()
+        self.assertNotIn("roles_created", audit[0])
 
 
 class ActorTests(ProvisionTenantTestBase):
@@ -423,7 +602,6 @@ class ActorTests(ProvisionTenantTestBase):
     def test_actor_case_insensitive(self):
         cfg = self._write_yaml(VALID_YAML)
         self._run("--config", cfg, "--actor", "CLIF@BARGE2RAIL.COM")
-        # UserAppRole was assigned by the case-insensitive-resolved actor
         uar = UserAppRole.objects.first()
         self.assertEqual(uar.assigned_by, self.actor)
 
@@ -444,9 +622,9 @@ class RollbackTests(ProvisionTenantTestBase):
             with self.assertRaises(RuntimeError):
                 self._run("--config", cfg, "--actor", "clif@barge2rail.com")
 
-        # All writes rolled back: Roles, Users, Bindings, Tenant.
-        # The target Application is unaffected (not created by this run).
-        self.assertEqual(Role.objects.count(), 0)
+        # All writes rolled back. The pre-existing target Application and
+        # Roles are unaffected (this run never created them).
+        self.assertEqual(Role.objects.count(), self._initial_role_count)
         self.assertEqual(
             User.objects.filter(
                 email__in=["alice@tstp.example.com", "bob@tstp.example.com"]
@@ -456,21 +634,19 @@ class RollbackTests(ProvisionTenantTestBase):
         self.assertEqual(UserAppRole.objects.count(), 0)
         self.assertEqual(Tenant.objects.filter(code="TSTP").count(), 0)
 
-        # Target Application still there
         self.assertEqual(Application.objects.filter(slug="testapp").count(), 1)
-
-        # No audit line written (audit happens after successful commit)
         self.assertEqual(self._audit_lines(), [])
 
 
 class EmailAuthTests(ProvisionTenantTestBase):
-    """Tests for the auth_type: email user creation path."""
+    """auth_type: email user creation. The role_code 'testapp_client' is
+    pre-seeded by the base setUp."""
 
     EMAIL_USER_YAML = _yaml_with_users(
         "  - email: briana@marianshipping.example.com\n"
         "    first_name: Briana\n"
         "    last_name: Jackson\n"
-        "    role: testapp_tste_client\n"
+        "    role_code: testapp_client\n"
         "    auth_type: email\n"
     )
 
@@ -478,7 +654,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: staff@barge2rail.com\n"
         "    first_name: Staff\n"
         "    last_name: Person\n"
-        "    role: testapp_tste_client\n"
+        "    role_code: testapp_client\n"
         "    auth_type: google\n"
     )
 
@@ -486,7 +662,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: noauth@example.com\n"
         "    first_name: Default\n"
         "    last_name: Auth\n"
-        "    role: testapp_tste_client\n"
+        "    role_code: testapp_client\n"
         # auth_type omitted on purpose
     )
 
@@ -494,12 +670,12 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: briana@marianshipping.example.com\n"
         "    first_name: Briana\n"
         "    last_name: Jackson\n"
-        "    role: testapp_tste_client\n"
+        "    role_code: testapp_client\n"
         "    auth_type: email\n"
         "  - email: staff@barge2rail.com\n"
         "    first_name: Staff\n"
         "    last_name: Person\n"
-        "    role: testapp_tste_client\n"
+        "    role_code: testapp_client\n"
         "    auth_type: google\n"
     )
 
@@ -507,13 +683,12 @@ class EmailAuthTests(ProvisionTenantTestBase):
         "  - email: anon@example.com\n"
         "    first_name: Anon\n"
         "    last_name: User\n"
-        "    role: testapp_tste_client\n"
+        "    role_code: testapp_client\n"
         "    auth_type: anonymous\n"
     )
 
     @staticmethod
     def _extract_password_for(stdout: str, email: str) -> str:
-        """Find the password printed next to an email in the credentials banner."""
         for raw in stdout.splitlines():
             stripped = raw.strip()
             if stripped.startswith(email):
@@ -595,7 +770,6 @@ class EmailAuthTests(ProvisionTenantTestBase):
         self.assertIn("auth_type", msg)
         self.assertIn("anonymous", msg)
         self.assertIn("users.0.auth_type", msg)
-        self.assertEqual(Role.objects.count(), 0)
 
     def test_existing_google_user_skipped_with_mismatch_warning(self):
         User.objects.create_user(
@@ -616,7 +790,7 @@ class EmailAuthTests(ProvisionTenantTestBase):
         if len(banner_split) > 1:
             self.assertNotIn("briana@marianshipping.example.com", banner_split[1])
 
-    def test_idempotent_rerun_email_user(self):
+    def test_idempotent_rerun_email_user_password_unchanged(self):
         cfg = self._write_yaml(self.EMAIL_USER_YAML)
         out1 = self._run("--config", cfg, "--actor", "clif@barge2rail.com")
         original_password = self._extract_password_for(
@@ -660,7 +834,6 @@ class AuditFailureTests(ProvisionTenantTestBase):
         self.assertIn("Audit log write failed", stderr_text)
         self.assertIn("disk full simulation", stderr_text)
 
-        # DB side effects succeeded
         self.assertEqual(
             User.objects.filter(email="briana@marianshipping.example.com").count(), 1
         )
@@ -675,7 +848,7 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
             "  - email: TestUser@Example.COM\n"
             "    first_name: Test\n"
             "    last_name: User\n"
-            "    role: testapp_tste_client\n"
+            "    role_code: testapp_client\n"
             "    auth_type: google\n"
         )
         cfg = self._write_yaml(yaml_content)
@@ -683,7 +856,6 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
 
         self.assertEqual(User.objects.filter(email="testuser@example.com").count(), 1)
         self.assertEqual(User.objects.filter(email="TestUser@Example.COM").count(), 0)
-
         self.assertIn("testuser@example.com", out)
 
         audit = self._audit_lines()
@@ -694,7 +866,7 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
             "  - email: alice@example.com\n"
             "    first_name: Alice\n"
             "    last_name: Case\n"
-            "    role: testapp_tste_client\n"
+            "    role_code: testapp_client\n"
             "    auth_type: google\n"
         )
         yaml1 = _yaml_with_users(base_users)
@@ -736,7 +908,7 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
             "  - email: bob@example.com\n"
             "    first_name: Bob\n"
             "    last_name: Builder\n"
-            "    role: testapp_tste_client\n"
+            "    role_code: testapp_client\n"
             "    auth_type: google\n"
         )
         cfg = self._write_yaml(yaml_content)
@@ -748,7 +920,5 @@ class EmailNormalizationTests(ProvisionTenantTestBase):
         self.assertIn("Multiple users", msg)
         self.assertIn("bob@example.com", msg)
 
-        # Nothing else created
-        self.assertEqual(Role.objects.count(), 0)
         self.assertEqual(UserAppRole.objects.count(), 0)
         self.assertEqual(Tenant.objects.filter(code="TSTE").count(), 0)

--- a/tenants/_template.yaml
+++ b/tenants/_template.yaml
@@ -1,8 +1,15 @@
-# Tenant provisioning template (bind-to-existing-application mode).
+# Tenant provisioning template (v3, bind-to-existing-roles mode).
 #
-# This command binds tenant-scoped Roles and UserAppRoles to an EXISTING
-# OAuth Application. It does NOT create the OAuth Application itself —
-# register it via /cbrt-ops/ first.
+# v3 BREAKING CHANGE from v2:
+#   - The `roles:` block has been removed. Roles must already exist on the
+#     target Application — this command no longer creates them.
+#   - Per-user `role:` was renamed to `role_code:` to make the bind-to-existing
+#     semantics explicit.
+#
+# This command binds Users and UserAppRoles to EXISTING Roles on an EXISTING
+# OAuth Application. It does NOT create OAuth Applications or Roles.
+#   - Register OAuth Applications via /cbrt-ops/.
+#   - Create Roles via admin or the `setup_rbac` management command.
 #
 # Copy this file to tenants/<tenant_code>.yaml (e.g. tenants/msp.yaml), fill in
 # real values, then run:
@@ -23,22 +30,17 @@ display_name: "Full Tenant Name"                  # used for the Tenant referenc
 # Register new client apps via /cbrt-ops/ before adding tenants to them.
 application_slug: sacks
 
-# Roles created on the target Application. Convention: <app_slug>_<tenant_code_lower>_<role>.
-# legacy_role is what client apps read from the JWT (application_roles.<slug>.role).
-# The code is machine-readable and must be unique within the target Application.
-roles:
-  - code: sacks_xxx_admin
-    name: "Sacks XXX Admin"
-    legacy_role: Admin
-  - code: sacks_xxx_office
-    name: "Sacks XXX Office"
-    legacy_role: Office
-  - code: sacks_xxx_client
-    name: "Sacks XXX Client"
-    legacy_role: Client
-
-# Users bound to roles under this tenant. One role per user per run;
-# add another YAML entry to give a user multiple roles.
+# Users bound to existing Roles on the target Application, scoped by tenant_code.
+# One role per user per entry; add another YAML entry to give a user multiple roles.
+#
+# role_code must match an EXISTING Role.code on the target Application.
+# Inspect available role codes with:
+#   python manage.py shell -c "from sso.models import Role; print(sorted(Role.objects.filter(application__slug='sacks').values_list('code', flat=True)))"
+#
+# CBRTConnect (`sacks`) shared roles, as of April 2026:
+#   - sacks_client  (tenant client users)
+#   - sacks_office  (cross-tenant office staff, no tenant_code)
+#   - sacks_admin   (admins, bypass)
 #
 # auth_type: "email" (default) or "google".
 #   - email   → user gets a temp password (printed once at end of real run)
@@ -52,31 +54,28 @@ users:
   - email: contact@example.com
     first_name: First
     last_name: Last
-    role: sacks_xxx_admin
+    role_code: sacks_client
     auth_type: email
 
   # Example Google OAuth user (staff on barge2rail.com):
   # - email: staff@barge2rail.com
   #   first_name: Staff
   #   last_name: Member
-  #   role: sacks_xxx_admin
+  #   role_code: sacks_office
   #   auth_type: google
 
 # ---------------------------------------------------------------------------
 # Alternate example: onboarding a tenant to PrimeTrade instead of CBRTConnect.
-# Copy-paste and adapt.
+# Copy-paste and adapt. Confirm the actual role codes on the primetrade
+# Application before using these literally.
 # ---------------------------------------------------------------------------
 #
 # tenant_code: YYY
 # display_name: "Full Tenant Name"
 # application_slug: primetrade
-# roles:
-#   - code: primetrade_yyy_admin
-#     name: "PrimeTrade YYY Admin"
-#     legacy_role: Admin
 # users:
 #   - email: contact@example.com
 #     first_name: First
 #     last_name: Last
-#     role: primetrade_yyy_admin
+#     role_code: primetrade_client
 #     auth_type: email


### PR DESCRIPTION
## Summary

**Breaking schema change.** v3 removes the top-level `roles:` block. The
command no longer creates Roles. Each user references an **existing** Role
on the target Application via the new `role_code` field (renamed from `role`
to make bind-to-existing semantics explicit at the call site).

## Why

PR #14 (v2) bound to an existing Application but still **created** per-tenant
Roles. Direct production DB inspection of MSP's broken records confirmed:

- CBRTConnect tenants share one Role namespace on the `sacks` Application
  (`sacks_client` 7 RFPs, `sacks_office` 18 RFPs, `sacks_admin` bypass).
  MTLO/URC/HLR/GNP/TRX all use these. Tenant differentiation lives at
  `UserAppRole.tenant_code`, not at the Role level.
- The MSP roles PR #14 created (`cbrtconnect_msp_admin/office/client`) had
  **zero** RoleFeaturePermissions. Briana would log in and see nothing —
  exactly what mem_1776883737265_5875 captured.

v3 makes the tool's narrow scope explicit: identity bindings only. RBAC
schema (Roles, Features, RoleFeaturePermissions) is created via admin or
the `setup_rbac` command, never by this tool.

## Contract

- `application_slug` resolves an existing Application (unchanged from v2).
- For each user, `role_code` resolves an existing Role on that Application.
  Missing role_codes error out with **all** offending users listed in one
  message, plus the existing role codes you can choose from. Operators fix
  every offender in one pass instead of fixing them one at a time.
- Top-level `roles:` triggers a v3-specific error message pointing at the
  v2->v3 migration path. Detection is by key presence (no `schema_version`
  needed).
- Tenant `get_or_create` no longer overwrites `display_name` on existing rows;
  prints a warning at the top of the plan if YAML and DB display_name disagree.
- Audit JSONL drops the `roles_created` field (the command doesn't create
  Roles). All other fields preserved.

Inherited unchanged from PR #14: dry-run, idempotency, transaction rollback,
case-insensitive email normalization, email-user temp-password banner,
audit-failure warn-and-continue, no `client_secret` banner, `--actor`
required for real runs.

## Test plan

- [x] `venv/bin/python3.14 manage.py test sso.tests.test_provision_tenant` -- 51 pass
- [x] Full SSO test suite has the same pre-existing failures as `main` (27 failures + 1 pytest-import error in `test_oauth_flow.py` that pre-dates this branch)
- [x] Pre-commit: black, flake8, bandit, django-upgrade, detect-secrets, isort all pass
- [ ] Codex review
- [ ] Post-merge: Clif deletes the orphan `msp` Application (cascades to its 3 zero-RFP roles + Briana's misplaced UserAppRole), rewrites `tenants/msp.yaml` per the v3 schema, dry-run + real run on Render shell, verifies Briana's UserAppRole binds her to `sacks_client` with `tenant_code='MSP'` and her Effective Permissions match other `sacks_client` users.

## Files changed

- `sso/management/commands/_tenant_schema.py` -- removed `RoleSpec`; renamed `UserSpec.role` -> `role_code`; dropped role-validation model_validators; added `LEGACY_ROLES_KEY_MESSAGE` constant for the v3 rejection message.
- `sso/management/commands/provision_tenant.py` -- removed all role-creation logic; added per-user role resolution against the resolved Application with all-errors-accumulated output; added pre-pydantic check that rejects legacy `roles:` key with the v3 message; added Tenant display_name mismatch warning.
- `sso/tests/test_provision_tenant.py` -- rewritten. 51 tests (was 35). New classes: `RoleResolutionTests` (6 tests for the new bind-to-existing semantics), `LegacyRolesKeyTests` (3 tests for v2->v3 rejection), `TenantTests` (2 tests for display_name handling). New cases under `ValidationTests`: unknown top-level key, unknown user field, old `role:` field name rejection, `role_code` required. Existing dry-run/idempotency/rollback/email-auth/audit/normalization/actor coverage preserved.
- `tenants/_template.yaml` -- v3 schema; explicit guidance that Roles must already exist; lists the actual `sacks_*` role codes as of April 2026; PrimeTrade alternate example.
- `docs/tenant-onboarding.md` -- top-of-file v3 BREAKING CHANGE section; updated "Does/Doesn't" to make role non-creation explicit; updated worked examples; documented role-not-found error and legacy-key-rejection error in "Common failures"; added v2->v3 migration section.

## Out of scope

- Operator cleanup of orphan MSP records on prod -- Clif handles via Render shell after merge.
- Deprecating legacy `sso_user_roles` / `sso_application_roles` tables -- separate PR.
- Touching `setup_rbac.py` or any RBAC seeding code.
- Google OAuth user creation flow improvements -- accepted via `auth_type: google` (existing v2 behavior preserved) but not the focus of this round.
- Changing the `--config <path>` CLI flag to a positional argument.
- Adding a `force_password_change` field on User -- the existing `/change-password/` UI flow remains the path.

## Rollback

Revert the PR. No production data is mutated by this code change itself; the
previous v2 contract becomes available again. Pre-existing UserAppRoles on
working tenants (MTLO/TRX/URC/HLR/GNP on `sacks`) are not affected by either
direction of revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)