### PR TITLE
chore(deps): remove orphaned Authlib pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 annotated-types==0.7.0
 anyio==4.11.0
 asgiref==3.10.0
-Authlib==1.6.5
 bandit==1.8.6
 cachetools==5.5.2
 certifi==2025.10.5


### PR DESCRIPTION
Removes orphaned `Authlib==1.6.5` pin from requirements.txt.

Investigation (worktree `barge2rail-auth-authlib`, plan committed at `AUTHLIB_UPGRADE_PLAN.md`) confirmed that:
- No Python file in this repo imports authlib or any submodule.
- No other dependency transitively pulls authlib.
- OAuth provider stack uses `django-oauth-toolkit`; JWTs use `rest_framework_simplejwt` + `PyJWT`; JWKS is hand-rolled on `cryptography`.
- The pin entered via commit `d758385` (M1 hardening, 2025-10-05) and is almost certainly a `pip freeze` artifact.

Removing the pin clears 5 unreachable GHSAs from pip-audit and reduces dependency surface. No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)